### PR TITLE
fix/frontend-sdkのexampleを動かす際に現場一覧が取得できない不具合に対する対応

### DIFF
--- a/src/lib/rcde-client.ts
+++ b/src/lib/rcde-client.ts
@@ -25,7 +25,7 @@ export class RCDEClient {
     this.baseUrl = opts.baseUrl ?? '';
     this.token = opts.accessToken;
     this.authType = opts.authType ?? '2legged';
-    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.fetchImpl = opts.fetchImpl ?? fetch.bind(globalThis);
   }
 
   private headers(): Record<string, string> {
@@ -143,14 +143,14 @@ export class RCDEClient {
     });
     if (!uploadRes.ok) throw new Error(`HTTP ${uploadRes.status}`);
     const uploadData = (await uploadRes.json()) as { presignedURL: string; contractFileId: number };
-    
+
     // presignedURLにファイルをアップロード
     const uploadFileRes = await this.fetchImpl(uploadData.presignedURL, {
       method: 'PUT',
       body: buffer,
     });
     if (!uploadFileRes.ok) throw new Error(`Upload failed: HTTP ${uploadFileRes.status}`);
-    
+
     // アップロード完了を通知
     const completeUrl = this.getApiPath(`/contractFile/uploaded/${uploadData.contractFileId}`);
     const completeRes = await this.fetchImpl(completeUrl, {


### PR DESCRIPTION
### 関連チケット
N/A
(竹内さんがexampleを動かしていた際の不具合報告を受け、その対応)

### 内容
frontend-sdkのexampleで現場一覧を取得できない不具合の解消です。

#### 不具合要因
fetchを変数に直接代入するとthisコンテキストが失われ、呼び出し時に「Illegal invocation」エラーが発生してしまう

#### 対応
fetchをglobalThisにバインドして、コンテキストを保持するようにする

### 変更
- fetchのIllegal invocationエラーの解消 4450c35a8478db8e50f2479e73c04df577e914ff

### スクリーンショット・動画キャプチャ
現場一覧を取得できることを確認
<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/d742c2b1-615e-475c-8291-76b7ce56ce78" />
