### PR TITLE
断面機能/断面クリッピングのギズモUIを外部提供するように実装

### DIFF
--- a/src/components/CrossSectionHandler.tsx
+++ b/src/components/CrossSectionHandler.tsx
@@ -1,0 +1,88 @@
+import { Line, PivotControls } from '@react-three/drei';
+import {
+  FC,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  ColorRepresentation,
+  Matrix4,
+  Plane,
+  Quaternion,
+  Vector3,
+} from 'three';
+import { useClippingPlanes } from '../contexts/clippingPlanes';
+
+export const CrossSectionHandler: FC = () => {
+  const [plane, setPlane] = useState<Plane>(
+    new Plane().setFromNormalAndCoplanarPoint(
+      new Vector3(0, 0, -1),
+      new Vector3()
+    )
+  );
+  const { setClippingPlanes } = useClippingPlanes();
+
+  useEffect(() => {
+    setClippingPlanes([plane]);
+    return () => {
+      setClippingPlanes([]);
+    };
+  }, [plane, setClippingPlanes]);
+
+  const handleDrag = useCallback((l: Matrix4) => {
+    const translation = new Vector3();
+    const rotation = new Quaternion();
+    l.decompose(translation, rotation, new Vector3());
+    const normal = new Vector3(0, 0, -1);
+    normal.applyQuaternion(rotation).normalize();
+    const n = new Plane().setFromNormalAndCoplanarPoint(normal, translation);
+    setPlane(n);
+  }, []);
+
+  return (
+    <PivotControls scale={50} fixed disableScaling onDrag={handleDrag}>
+      <CrossSectionPlane size={1e2} />
+    </PivotControls>
+  );
+};
+
+export const CrossSectionPlane: FC<{
+  size: number;
+  color?: ColorRepresentation;
+  opacity?: number;
+}> = ({ size, color = 'yellow', opacity = 0.85 }) => {
+  const rectangle = useMemo(() => {
+    const pts = [
+      new Vector3(-size / 2, -size / 2, 0),
+      new Vector3(size / 2, -size / 2, 0),
+      new Vector3(size / 2, size / 2, 0),
+      new Vector3(-size / 2, size / 2, 0),
+    ];
+    return [...pts, pts[0]];
+  }, [size]);
+
+  const lt2rb = useMemo(() => {
+    return [
+      new Vector3(-size / 2, -size / 2, 0),
+      new Vector3(size / 2, size / 2, 0),
+    ];
+  }, [size]);
+
+  const rt2lb = useMemo(() => {
+    return [
+      new Vector3(size / 2, -size / 2, 0),
+      new Vector3(-size / 2, size / 2, 0),
+    ];
+  }, [size]);
+
+  return (
+    <group>
+      <Line points={rectangle} color={color} transparent opacity={opacity} />
+      <Line points={lt2rb} color={color} transparent opacity={opacity} />
+      <Line points={rt2lb} color={color} transparent opacity={opacity} />
+    </group>
+  );
+};
+

--- a/src/contexts/clippingPlanes.tsx
+++ b/src/contexts/clippingPlanes.tsx
@@ -1,0 +1,38 @@
+import { Dispatch, FC, ReactNode, SetStateAction, createContext, useContext, useState } from 'react';
+import { Plane } from 'three';
+
+export type ClippingPlanesContextProps = {
+  clippingPlanes: Plane[];
+  setClippingPlanes: Dispatch<SetStateAction<Plane[]>>;
+};
+
+export const ClippingPlanesContext = createContext<ClippingPlanesContextProps>({
+  clippingPlanes: [],
+  setClippingPlanes: () => {},
+});
+
+export const ClippingPlanesProvider: FC<{
+  children?: ReactNode;
+}> = ({ children }) => {
+  const [clippingPlanes, setClippingPlanes] = useState<Plane[]>([]);
+
+  return (
+    <ClippingPlanesContext.Provider
+      value={{
+        clippingPlanes,
+        setClippingPlanes,
+      }}
+    >
+      {children}
+    </ClippingPlanesContext.Provider>
+  );
+};
+
+export const useClippingPlanes = (): ClippingPlanesContextProps => {
+  const context = useContext(ClippingPlanesContext);
+  if (!context) {
+    throw new Error('useClippingPlanes must be used within a ClippingPlanesProvider');
+  }
+  return context;
+};
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,5 @@ export { ContractFileView } from "./components/ContractFileView";
 export type { ContractFileProps } from "./components/ContractFileView";
 export { ReferencePointAxis } from "./components/ReferencePointAxis";
 export type { ReferencePointAxisProps } from "./components/ReferencePointAxis";
+export { CrossSectionHandler, CrossSectionPlane } from './components/CrossSectionHandler';
+export { ClippingPlanesProvider, useClippingPlanes, ClippingPlanesContext, type ClippingPlanesContextProps } from './contexts/clippingPlanes';


### PR DESCRIPTION
### 関連チケット
 - [【モニタリングアプリ】断面表示実装](https://www.notion.so/amdlab/29a6a91e3bcb80f68797db91ee78619c)

### 内容
断面表示機能のギズモUIをfrontend-sdkから外部提供するようにするためのPRです。

### 変更
 - frontend-sdkからRCDEの断面表示用ギズモをエクスポートするようにする 897609b
 
### スクリーンショット・動画キャプチャ
#### RCDE

https://github.com/user-attachments/assets/16a07862-1b68-4a31-90e6-074919baf295



#### モニタリングアプリ

https://github.com/user-attachments/assets/a7b15b4e-3669-4754-8625-42680cdec287


