### PR TITLE
chore: CI 基盤（vitest / lint / format / build）と GitHub Actions を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.21.1"
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint
+      - run: yarn format:check
+      - run: yarn build
+      - run: yarn test

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist-ssr
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+.cursor
 .idea
 .DS_Store
 *.suo

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+dist/
+node_modules/
+yarn.lock
+package-lock.json
+.cursor/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 100
+}

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Next.js（App Router構成）および React Three Fiber をベースとし、�
 
 ## 開発環境要件
 
-| 項目 | バージョン | 備考 |
-|------|-------------|------|
-| Node.js | 20.x 以上 | LTS推奨 |
-| React | **18.3.1 固定** | Three.js互換のため他バージョン不可 |
-| Next.js | **14.2.5 固定** | Three.js／React Three Fiber間の依存制約あり |
-| Vite | ^5.x | ライブラリビルド用 |
-| TypeScript | ^5.x | 型定義完全対応 |
-| Three.js | ^0.164.x | `@react-three/fiber` 依存 |
+| 項目       | バージョン      | 備考                                        |
+| ---------- | --------------- | ------------------------------------------- |
+| Node.js    | 20.x 以上       | LTS推奨                                     |
+| React      | **18.3.1 固定** | Three.js互換のため他バージョン不可          |
+| Next.js    | **14.2.5 固定** | Three.js／React Three Fiber間の依存制約あり |
+| Vite       | ^5.x            | ライブラリビルド用                          |
+| TypeScript | ^5.x            | 型定義完全対応                              |
+| Three.js   | ^0.164.x        | `@react-three/fiber` 依存                   |
 
 > ⚠️ **React/Nextバージョンは厳密固定です。**
 >
@@ -35,7 +35,7 @@ npm、またはyarnを使用してインストールします。
 
 ```bash
 npm install @i-con/frontend-sdk
-# or 
+# or
 yarn add @i-con/frontend-sdk
 ```
 
@@ -74,13 +74,13 @@ packages/
 
 ## 主な機能
 
-| モジュール | 概要 |
-|-----------|------|
-| ViewerBridge | Three.jsビューワーとReact間のブリッジ処理 |
-| useViewer | 点群・基準面の表示制御用フック |
-| useAuth | RCDE OAuth 3-legged認証対応 |
-| FileUploadModal | S3/RCDE両対応のアップロードモーダル |
-| contractFiles | 契約項目別ファイル管理用コンテキスト |
+| モジュール      | 概要                                      |
+| --------------- | ----------------------------------------- |
+| ViewerBridge    | Three.jsビューワーとReact間のブリッジ処理 |
+| useViewer       | 点群・基準面の表示制御用フック            |
+| useAuth         | RCDE OAuth 3-legged認証対応               |
+| FileUploadModal | S3/RCDE両対応のアップロードモーダル       |
+| contractFiles   | 契約項目別ファイル管理用コンテキスト      |
 
 ---
 
@@ -169,26 +169,21 @@ export default function ViewerPanel() {
     };
   }, []);
 
-  return (
-    <div
-      ref={viewerRef}
-      style={{ width: "100%", height: "600px", background: "#111" }}
-    />
-  );
+  return <div ref={viewerRef} style={{ width: "100%", height: "600px", background: "#111" }} />;
 }
 ```
 
 ### 主なAPI一覧
 
-| メソッド | 機能概要 |
-|---------|---------|
-| `init(container: HTMLElement, options?: ViewerOptions)` | ビューワー初期化 |
-| `loadPointCloud({ url, color })` | 点群データをロード |
-| `setTransform({ translation, rotation, scale })` | オブジェクトの位置・回転・拡縮設定 |
-| `setCamera({ position, target })` | カメラ位置と注視点を設定 |
-| `resetCamera()` | カメラを初期位置に戻す |
-| `animate(callback: (time: number) => void)` | 毎フレーム呼ばれるアニメーション関数登録 |
-| `dispose()` | ビューワー破棄とメモリ解放 |
+| メソッド                                                | 機能概要                                 |
+| ------------------------------------------------------- | ---------------------------------------- |
+| `init(container: HTMLElement, options?: ViewerOptions)` | ビューワー初期化                         |
+| `loadPointCloud({ url, color })`                        | 点群データをロード                       |
+| `setTransform({ translation, rotation, scale })`        | オブジェクトの位置・回転・拡縮設定       |
+| `setCamera({ position, target })`                       | カメラ位置と注視点を設定                 |
+| `resetCamera()`                                         | カメラを初期位置に戻す                   |
+| `animate(callback: (time: number) => void)`             | 毎フレーム呼ばれるアニメーション関数登録 |
+| `dispose()`                                             | ビューワー破棄とメモリ解放               |
 
 ### 補足
 
@@ -311,7 +306,7 @@ const App = () => {
 
 ## 更新履歴
 
-| バージョン | 日付 | 内容 |
-|-----------|------|------|
-| 1.0.0 | 2025-07-30 | 初版作成 |
-| 1.1.0 | 2025-10-21 | React 18.3.1 / Next 14.2.5 固定明記、Three.js依存性追記、ViewerBridge使用例追加、RCDE認証要約追加 |
+| バージョン | 日付       | 内容                                                                                              |
+| ---------- | ---------- | ------------------------------------------------------------------------------------------------- |
+| 1.0.0      | 2025-07-30 | 初版作成                                                                                          |
+| 1.1.0      | 2025-10-21 | React 18.3.1 / Next 14.2.5 固定明記、Three.js依存性追記、ViewerBridge使用例追加、RCDE認証要約追加 |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,28 +1,25 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
+import js from "@eslint/js";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ['dist', '**/node_modules/**', '**/.next/**'] },
+  { ignores: ["dist", "**/node_modules/**", "**/.next/**"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
-    files: ['**/*.{ts,tsx}'],
+    files: ["**/*.{ts,tsx}"],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
     },
     plugins: {
-      'react-hooks': reactHooks,
-      'react-refresh': reactRefresh,
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      'react-refresh/only-export-components': [
-        'warn',
-        { allowConstantExport: true },
-      ],
+      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
     },
-  },
-)
+  }
+);

--- a/example/App.css
+++ b/example/App.css
@@ -1,5 +1,6 @@
-
-html, body, div#root {
+html,
+body,
+div#root {
   margin: 0;
   padding: 0;
   width: 100%;

--- a/example/README.md
+++ b/example/README.md
@@ -4,12 +4,14 @@
 **Reactは 18.3.1 固定**で、Three.js との依存関係を安定させています（Next.js を使う場合は **14.2.5** 固定推奨）。
 
 ## 要件
+
 - Node.js 20.x 以上（LTS推奨）
 - React 18.3.1 固定
 - three ^0.171.0
 - （Next.js を使用する別例の場合は Next 14.2.5 固定）
 
 ## セットアップ
+
 ```bash
 cd example
 npm install
@@ -19,10 +21,12 @@ npm run dev
 ```
 
 ## 主要画面
+
 - Home（発注者/受注者向けのUIダミー）
 - **Viewer**（`ViewerBridge` を使った 3D 表示サンプル）
 
 ## Viewer の使い方
+
 `components/ViewerPanel.tsx` を参照してください。
 
 - `ViewerBridge.init(container, options)` で初期化
@@ -31,6 +35,7 @@ npm run dev
 - `resetCamera()` / `setTransform(...)` の操作ボタン付き
 
 ## .env
+
 `example/.env.example` をコピーして `.env` を作成してください。
 
 ```env
@@ -45,5 +50,6 @@ VITE_AUTH_TYPE=2legged
 > ※ `VITE_AUTH_TYPE` は `2legged` または `3legged` を指定します（デフォルトは `2legged`、現在は2leggedのみサポート）。
 
 ## 注意点
+
 - three は Vite の `optimizeDeps.include` に含めています。
 - SDK側の `ViewerBridge` は React 18.3.1 前提です。バージョンを変えると Reconciler 差異で動作しない可能性があります。

--- a/example/components/ConstructionDetail.tsx
+++ b/example/components/ConstructionDetail.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  List,
-  ListItem,
-  ListItemButton,
-  Modal,
-  Typography
-} from "@mui/material";
+import { Box, List, ListItem, ListItemButton, Modal, Typography } from "@mui/material";
 import { RCDEClient } from "../../src/lib/rcde-client";
 import { FC, useCallback, useEffect, useState } from "react";
 import { useClient } from "../../src/contexts/client";
@@ -94,9 +87,7 @@ const ConstructionDetail: FC<ConstructionDetailProps> = ({ id: constructionId, o
       ) : null}
       <List>
         <ListItem>
-          <Typography variant="body1">
-            工事名称: {construction?.name}
-          </Typography>
+          <Typography variant="body1">工事名称: {construction?.name}</Typography>
         </ListItem>
         <ListItem>
           <ListItemButton onClick={handleNewContract}>契約作成</ListItemButton>
@@ -114,9 +105,7 @@ const ConstructionDetail: FC<ConstructionDetailProps> = ({ id: constructionId, o
               >
                 <Box>
                   <Typography variant="body1">契約名称: {c.name}</Typography>
-                  <Typography variant="body2">
-                    契約日: {c.contractedAt}
-                  </Typography>
+                  <Typography variant="body2">契約日: {c.contractedAt}</Typography>
                   <Typography variant="body2">状態: {c.status}</Typography>
                 </Box>
               </ListItemButton>

--- a/example/components/ConstructionForm.tsx
+++ b/example/components/ConstructionForm.tsx
@@ -1,27 +1,15 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  Box,
-  Button,
-  List,
-  ListItem,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Box, Button, List, ListItem, TextField, Typography } from "@mui/material";
 import { DatePicker } from "@mui/x-date-pickers";
 import { FC, useCallback, useMemo, useState } from "react";
 import { Controller, SubmitHandler, useForm } from "react-hook-form";
-import {
-  CreateConstructionSchema,
-  createConstructionSchema,
-} from "../schemas/construction";
+import { CreateConstructionSchema, createConstructionSchema } from "../schemas/construction";
 
 export type ConstructionFormProps = {
   onSubmit: (values: CreateConstructionSchema) => void;
 };
 
-const ConstructionForm: FC<ConstructionFormProps> = ({
-  onSubmit
-}) => {
+const ConstructionForm: FC<ConstructionFormProps> = ({ onSubmit }) => {
   const [loading, setLoading] = useState(false);
 
   const {
@@ -92,14 +80,11 @@ const ConstructionForm: FC<ConstructionFormProps> = ({
                     size: "small",
                     fullWidth: true,
                     error: !!errors.contractedAt,
-                    helperText:
-                      errors.contractedAt && errors.contractedAt.message,
+                    helperText: errors.contractedAt && errors.contractedAt.message,
                   },
                 }}
                 onChange={(value: Date | null) =>
-                  value === null
-                    ? field.onChange(undefined)
-                    : field.onChange(value)
+                  value === null ? field.onChange(undefined) : field.onChange(value)
                 }
               />
             )}
@@ -126,9 +111,7 @@ const ConstructionForm: FC<ConstructionFormProps> = ({
                   },
                 }}
                 onChange={(value: Date | null) =>
-                  value === null
-                    ? field.onChange(undefined)
-                    : field.onChange(value)
+                  value === null ? field.onChange(undefined) : field.onChange(value)
                 }
               />
             )}
@@ -172,9 +155,7 @@ const ConstructionForm: FC<ConstructionFormProps> = ({
               endAdornment: "%",
             }}
             error={!!errors.advancePaymentRate}
-            helperText={
-              errors.advancePaymentRate && errors.advancePaymentRate.message
-            }
+            helperText={errors.advancePaymentRate && errors.advancePaymentRate.message}
             {...register("advancePaymentRate", {
               valueAsNumber: true,
             })}
@@ -201,12 +182,7 @@ const ConstructionForm: FC<ConstructionFormProps> = ({
           return (
             <ListItem key={item.key}>
               <Box display="flex" width={1}>
-                <Box
-                  display={"flex"}
-                  alignItems={"center"}
-                  marginRight={2}
-                  minWidth={100}
-                >
+                <Box display={"flex"} alignItems={"center"} marginRight={2} minWidth={100}>
                   <Typography variant="caption">{item.label}</Typography>
                 </Box>
                 {item.component}

--- a/example/components/ConstructionList.tsx
+++ b/example/components/ConstructionList.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  List,
-  ListItem,
-  ListItemButton,
-  Modal,
-  Typography,
-} from "@mui/material";
+import { Box, List, ListItem, ListItemButton, Modal, Typography } from "@mui/material";
 import { FC, useCallback, useEffect, useState } from "react";
 import { useClient } from "../../src/contexts/client";
 import { RCDEClient } from "../../src/lib/rcde-client";
@@ -73,9 +66,7 @@ const ConstructionList: FC<ConstructionListProps> = ({ onSelect }) => {
       ) : null}
       <List>
         <ListItem>
-          <ListItemButton onClick={handleNewConstruction}>
-            現場作成
-          </ListItemButton>
+          <ListItemButton onClick={handleNewConstruction}>現場作成</ListItemButton>
         </ListItem>
         {constructions?.map((c) => {
           const { id } = c;
@@ -91,16 +82,10 @@ const ConstructionList: FC<ConstructionListProps> = ({ onSelect }) => {
                 <Box>
                   <Typography variant="body1">工事名称: {c.name}</Typography>
                   <Typography variant="caption">住所: {c.address}</Typography>
-                  <Typography variant="body2">
-                    契約日: {c.contractedAt}
-                  </Typography>
+                  <Typography variant="body2">契約日: {c.contractedAt}</Typography>
                   <Typography variant="body2">完成期日: {c.period}</Typography>
-                  <Typography variant="body2">
-                    請負金額: ¥{c.contractAmount}
-                  </Typography>
-                  <Typography variant="body2">
-                    前払い金額率:{c.advancePaymentRate}%
-                  </Typography>
+                  <Typography variant="body2">請負金額: ¥{c.contractAmount}</Typography>
+                  <Typography variant="body2">前払い金額率:{c.advancePaymentRate}%</Typography>
                 </Box>
               </ListItemButton>
             </ListItem>

--- a/example/components/ContractForm.tsx
+++ b/example/components/ContractForm.tsx
@@ -1,12 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  Box,
-  Button,
-  List,
-  ListItem,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Box, Button, List, ListItem, TextField, Typography } from "@mui/material";
 import { DatePicker } from "@mui/x-date-pickers";
 import { FC, useCallback, useMemo, useState } from "react";
 import { Controller, SubmitHandler, useForm } from "react-hook-form";
@@ -71,14 +64,11 @@ const ContractForm: FC<ContractFormProps> = ({ onSubmit }) => {
                     size: "small",
                     fullWidth: true,
                     error: !!errors.contractedAt,
-                    helperText:
-                      errors.contractedAt && errors.contractedAt.message,
+                    helperText: errors.contractedAt && errors.contractedAt.message,
                   },
                 }}
                 onChange={(value: Date | null) =>
-                  value === null
-                    ? field.onChange(undefined)
-                    : field.onChange(value)
+                  value === null ? field.onChange(undefined) : field.onChange(value)
                 }
               />
             )}
@@ -154,12 +144,7 @@ const ContractForm: FC<ContractFormProps> = ({ onSubmit }) => {
           return (
             <ListItem key={item.key}>
               <Box display="flex" width={1}>
-                <Box
-                  display={"flex"}
-                  alignItems={"center"}
-                  marginRight={2}
-                  minWidth={100}
-                >
+                <Box display={"flex"} alignItems={"center"} marginRight={2} minWidth={100}>
                   <Typography variant="caption">{item.label}</Typography>
                 </Box>
                 {item.component}

--- a/example/components/Root.tsx
+++ b/example/components/Root.tsx
@@ -32,12 +32,12 @@ const Root: FC = () => {
   const [error, setError] = useState<string | null>(null);
 
   const baseUrl = useMemo(() => {
-    return import.meta.env.VITE_API_BASE_URL || 'https://api.rcde.jp';
+    return import.meta.env.VITE_API_BASE_URL || "https://api.rcde.jp";
   }, []);
 
   const authType = useMemo(() => {
     const type = import.meta.env.VITE_AUTH_TYPE;
-    return (type === '3legged' ? '3legged' : '2legged') as '2legged' | '3legged';
+    return (type === "3legged" ? "3legged" : "2legged") as "2legged" | "3legged";
   }, []);
 
   useEffect(() => {
@@ -47,7 +47,7 @@ const Root: FC = () => {
       const origin = window.location.origin;
 
       if (!clientId || !clientSecret) {
-        setError('VITE_CLIENT_ID と VITE_CLIENT_SECRET を設定してください');
+        setError("VITE_CLIENT_ID と VITE_CLIENT_SECRET を設定してください");
         return;
       }
 
@@ -55,20 +55,20 @@ const Root: FC = () => {
         let tokenEndpoint: string;
         let requestBody: Record<string, string>;
 
-        if (authType === '2legged') {
+        if (authType === "2legged") {
           tokenEndpoint = `${baseUrl}/ext/v2/auth/token`;
           requestBody = { clientId, clientSecret };
         } else {
           // 3leggedの場合はOAuthフローが必要（今回は未実装）
-          setError('3legged認証は現在サポートされていません');
+          setError("3legged認証は現在サポートされていません");
           return;
         }
 
         const response = await fetch(tokenEndpoint, {
-          method: 'POST',
+          method: "POST",
           headers: {
-            'Content-Type': 'application/json',
-            'Origin': origin,
+            "Content-Type": "application/json",
+            Origin: origin,
           },
           body: JSON.stringify(requestBody),
         });
@@ -91,9 +91,9 @@ const Root: FC = () => {
         });
         setError(null);
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'トークン取得に失敗しました';
+        const message = err instanceof Error ? err.message : "トークン取得に失敗しました";
         setError(message);
-        console.error('Failed to fetch access token:', err);
+        console.error("Failed to fetch access token:", err);
       }
     };
 
@@ -147,12 +147,7 @@ const Root: FC = () => {
         );
       }
       case "construction": {
-        return (
-          <ConstructionDetail
-            id={page.constructionId}
-            onSelect={handleSelectContract}
-          />
-        );
+        return <ConstructionDetail id={page.constructionId} onSelect={handleSelectContract} />;
       }
       case "contract": {
         return (
@@ -173,8 +168,8 @@ const Root: FC = () => {
     return (
       <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={ja}>
         <Box sx={{ p: 2 }}>
-          <Box sx={{ color: 'error.main', mb: 2 }}>エラー: {error}</Box>
-          <Box sx={{ fontSize: '0.875rem', color: 'text.secondary' }}>
+          <Box sx={{ color: "error.main", mb: 2 }}>エラー: {error}</Box>
+          <Box sx={{ fontSize: "0.875rem", color: "text.secondary" }}>
             .envファイルに VITE_CLIENT_ID と VITE_CLIENT_SECRET を設定してください。
           </Box>
         </Box>
@@ -194,22 +189,21 @@ const Root: FC = () => {
     <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={ja}>
       <Box width={1} height={1} display="flex" flexDirection={"column"}>
         <Box>
-          <Button
-            fullWidth
-            onClick={handleBack}
-            disabled={page.variant === "root"}
-          >
+          <Button fullWidth onClick={handleBack} disabled={page.variant === "root"}>
             戻る
           </Button>
         </Box>
         {p}
       </Box>
-    <Box sx={{ p:2, display:'flex', gap:1 }}>
-  <Button variant="outlined" onClick={() => setPage({ variant: "root" })}>Home</Button>
-  <Button variant="outlined" onClick={() => setPage({ variant: "viewer" })}>Viewer</Button>
-</Box>
-</LocalizationProvider>
-
+      <Box sx={{ p: 2, display: "flex", gap: 1 }}>
+        <Button variant="outlined" onClick={() => setPage({ variant: "root" })}>
+          Home
+        </Button>
+        <Button variant="outlined" onClick={() => setPage({ variant: "viewer" })}>
+          Viewer
+        </Button>
+      </Box>
+    </LocalizationProvider>
   );
 };
 

--- a/example/components/ViewerPanel.tsx
+++ b/example/components/ViewerPanel.tsx
@@ -44,7 +44,9 @@ export function ViewerPanel({ pointCloudUrl = "../example-data/sample.las" }: Vi
     <div style={{ height: "100%", display: "flex", flexDirection: "column" }}>
       <div style={{ padding: 8, gap: 8, display: "flex" }}>
         <button onClick={() => ViewerBridge.resetCamera()}>Reset Camera</button>
-        <button onClick={() => ViewerBridge.setTransform({ translation: { x: 0, y: 0, z: 0 } })}>Reset Transform</button>
+        <button onClick={() => ViewerBridge.setTransform({ translation: { x: 0, y: 0, z: 0 } })}>
+          Reset Transform
+        </button>
       </div>
       <div ref={containerRef} style={{ flex: 1, background: "#111" }} />
     </div>

--- a/example/main.tsx
+++ b/example/main.tsx
@@ -1,9 +1,9 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App.tsx";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />
-  </StrictMode>,
-)
+  </StrictMode>
+);

--- a/example/schemas/construction.ts
+++ b/example/schemas/construction.ts
@@ -1,24 +1,16 @@
 import { z, ZodErrorMap, ZodIssueCode, ZodParsedType } from "zod";
 
 const contractedAtErrorMap: ZodErrorMap = (issue, ctx) => {
-  if (
-    issue.code === ZodIssueCode.invalid_type &&
-    issue.received === ZodParsedType.undefined
-  )
+  if (issue.code === ZodIssueCode.invalid_type && issue.received === ZodParsedType.undefined)
     return { message: "契約日を入力してください" };
-  if (issue.code === ZodIssueCode.invalid_date)
-    return { message: "契約日を入力してください" };
+  if (issue.code === ZodIssueCode.invalid_date) return { message: "契約日を入力してください" };
   return { message: ctx.defaultError };
 };
 
 const periodErrorMap: ZodErrorMap = (issue, ctx) => {
-  if (
-    issue.code === ZodIssueCode.invalid_type &&
-    issue.received === ZodParsedType.undefined
-  )
+  if (issue.code === ZodIssueCode.invalid_type && issue.received === ZodParsedType.undefined)
     return { message: "完成期日を入力してください" };
-  if (issue.code === ZodIssueCode.invalid_date)
-    return { message: "完成期日を入力してください" };
+  if (issue.code === ZodIssueCode.invalid_date) return { message: "完成期日を入力してください" };
   return { message: ctx.defaultError };
 };
 

--- a/example/schemas/contract.ts
+++ b/example/schemas/contract.ts
@@ -1,34 +1,28 @@
-import { ZodErrorMap, ZodIssueCode, ZodParsedType, z } from 'zod';
+import { ZodErrorMap, ZodIssueCode, ZodParsedType, z } from "zod";
 
 const dateErrorMap: ZodErrorMap = (issue, ctx) => {
-  if (
-    issue.code === ZodIssueCode.invalid_type &&
-    issue.received === ZodParsedType.undefined
-  )
-    return { message: '契約日を入力してください' };
-  if (issue.code === ZodIssueCode.invalid_date)
-    return { message: '契約日を入力してください' };
+  if (issue.code === ZodIssueCode.invalid_type && issue.received === ZodParsedType.undefined)
+    return { message: "契約日を入力してください" };
+  if (issue.code === ZodIssueCode.invalid_date) return { message: "契約日を入力してください" };
   return { message: ctx.defaultError };
 };
 
 export const createContractSchema = z.object({
-  name: z.string().nonempty({ message: '契約項目名を入力してください' }),
+  name: z.string().nonempty({ message: "契約項目名を入力してください" }),
   contractedAt: z.date({ errorMap: dateErrorMap }),
-  email: z
-    .string()
-    .email({ message: '管理者メールアドレスを入力してください' }),
+  email: z.string().email({ message: "管理者メールアドレスを入力してください" }),
   unitPrice: z
-    .number({ invalid_type_error: '契約単価を入力してください' })
-    .nonnegative({ message: '契約単価は0以上の数字を入力してください' }),
+    .number({ invalid_type_error: "契約単価を入力してください" })
+    .nonnegative({ message: "契約単価は0以上の数字を入力してください" }),
   unitVolume: z
-    .number({ invalid_type_error: '契約数量を入力してください' })
-    .nonnegative({ message: '契約数量は0以上の数字を入力してください' }),
+    .number({ invalid_type_error: "契約数量を入力してください" })
+    .nonnegative({ message: "契約数量は0以上の数字を入力してください" }),
 });
 
 export type CreateContractSchema = z.infer<typeof createContractSchema>;
 
 export const updateContractSchema = z.object({
-  name: z.string().nonempty({ message: '契約項目名を入力してください' }),
+  name: z.string().nonempty({ message: "契約項目名を入力してください" }),
 });
 
 export type UpdateContractSchema = z.infer<typeof updateContractSchema>;

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -1,12 +1,12 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react-swc'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
 
 export default defineConfig({
   plugins: [react()],
   optimizeDeps: {
-    include: ['three']
+    include: ["three"],
   },
   server: {
-    port: 5173
-  }
-})
+    port: 5173,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     "dev": "vite example",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "preview": "vite preview",
     "prepublishOnly": "npm run build"
   },
@@ -33,6 +37,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@hookform/resolvers": "^3.9.1",
+    "@i-con/pcd-viewer": "0.0.26",
     "@mui/icons-material": "^6.2.0",
     "@mui/material": "^6.1.10",
     "@mui/x-date-pickers": "^7.23.1",
@@ -40,7 +45,6 @@
     "chroma-js": "^3.1.2",
     "date-fns": "^2.30.0",
     "js-quadtree": "^3.3.6",
-    "@i-con/pcd-viewer": "0.0.26",
     "pngjs": "^7.0.0",
     "react-hook-form": "^7.54.0",
     "xstate": "^5.19.0",
@@ -67,13 +71,15 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.12.0",
+    "prettier": "^3.8.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "three": "^0.171.0",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.15.0",
     "vite": "^6.0.1",
-    "vite-plugin-dts": "^4.4.0"
+    "vite-plugin-dts": "^4.4.0",
+    "vitest": "^2.1"
   },
   "volta": {
     "node": "22.21.1"

--- a/src/bridge/viewerBridge.ts
+++ b/src/bridge/viewerBridge.ts
@@ -1,13 +1,13 @@
-export type UpAxis = 'Y' | 'Z';
+export type UpAxis = "Y" | "Z";
 
 // 座標系の定義
 export const CoordinateSystem = {
-  RightHandedXUp: 'RIGHT_HANDED_X_UP',
-  LeftHandedXUp: 'LEFT_HANDED_X_UP',
-  RightHandedYUp: 'RIGHT_HANDED_Y_UP',
-  LeftHandedYUp: 'LEFT_HANDED_Y_UP',
-  RightHandedZUp: 'RIGHT_HANDED_Z_UP',
-  LeftHandedZUp: 'LEFT_HANDED_Z_UP',
+  RightHandedXUp: "RIGHT_HANDED_X_UP",
+  LeftHandedXUp: "LEFT_HANDED_X_UP",
+  RightHandedYUp: "RIGHT_HANDED_Y_UP",
+  LeftHandedYUp: "LEFT_HANDED_Y_UP",
+  RightHandedZUp: "RIGHT_HANDED_Z_UP",
+  LeftHandedZUp: "LEFT_HANDED_Z_UP",
 } as const;
 
 export type CoordinateSystemType = (typeof CoordinateSystem)[keyof typeof CoordinateSystem];
@@ -26,36 +26,36 @@ export type ViewerAppearance = {
   fileId?: number; // R-CDEのデータベースに登録されているファイルID
 };
 
-const CHANNEL = 'RCDE_VIEWER_CMD';
+const CHANNEL = "RCDE_VIEWER_CMD";
 
 type Command =
-  | { type: 'SET_TRANSFORM'; payload: ViewerTransform }
-  | { type: 'SET_APPEARANCE'; payload: ViewerAppearance }
-  | { type: 'RESET' };
+  | { type: "SET_TRANSFORM"; payload: ViewerTransform }
+  | { type: "SET_APPEARANCE"; payload: ViewerAppearance }
+  | { type: "RESET" };
 
 function post(cmd: Command) {
-  if (typeof window === 'undefined') return;
-  window.postMessage({ channel: CHANNEL, cmd }, '*');
+  if (typeof window === "undefined") return;
+  window.postMessage({ channel: CHANNEL, cmd }, "*");
 }
 
 export const ViewerBridge = {
   setTransform(tx: ViewerTransform) {
-    post({ type: 'SET_TRANSFORM', payload: tx });
+    post({ type: "SET_TRANSFORM", payload: tx });
   },
   setAppearance(app: ViewerAppearance) {
-    post({ type: 'SET_APPEARANCE', payload: app });
+    post({ type: "SET_APPEARANCE", payload: app });
   },
   reset() {
-    post({ type: 'RESET' });
+    post({ type: "RESET" });
   },
   addListener(handler: (cmd: Command) => void) {
-    if (typeof window === 'undefined') return () => {};
+    if (typeof window === "undefined") return () => {};
     const listener = (e: MessageEvent) => {
       if (!e?.data || e.data.channel !== CHANNEL) return;
       handler(e.data.cmd as Command);
     };
-    window.addEventListener('message', listener);
-    return () => window.removeEventListener('message', listener);
+    window.addEventListener("message", listener);
+    return () => window.removeEventListener("message", listener);
   },
 };
 

--- a/src/components/ContractFileView.tsx
+++ b/src/components/ContractFileView.tsx
@@ -16,30 +16,33 @@ import { ContractFile } from "../contexts/contractFiles";
 
 // 座標系の型定義
 type CoordinateSystemType =
-  | 'RIGHT_HANDED_X_UP'
-  | 'LEFT_HANDED_X_UP'
-  | 'RIGHT_HANDED_Y_UP'
-  | 'LEFT_HANDED_Y_UP'
-  | 'RIGHT_HANDED_Z_UP'
-  | 'LEFT_HANDED_Z_UP';
+  | "RIGHT_HANDED_X_UP"
+  | "LEFT_HANDED_X_UP"
+  | "RIGHT_HANDED_Y_UP"
+  | "LEFT_HANDED_Y_UP"
+  | "RIGHT_HANDED_Z_UP"
+  | "LEFT_HANDED_Z_UP";
 
 // 座標系ごとの変換定義
-const COORDINATE_SYSTEM_TRANSFORMS: Record<CoordinateSystemType, {
-  rotation: [number, number, number]; // Euler angles [x, y, z] (radians)
-  scale: [number, number, number];
-}> = {
+const COORDINATE_SYSTEM_TRANSFORMS: Record<
+  CoordinateSystemType,
+  {
+    rotation: [number, number, number]; // Euler angles [x, y, z] (radians)
+    scale: [number, number, number];
+  }
+> = {
   // 右手系 Z Up → 変換不要
-  'RIGHT_HANDED_Z_UP': { rotation: [0, 0, 0], scale: [1, 1, 1] },
+  RIGHT_HANDED_Z_UP: { rotation: [0, 0, 0], scale: [1, 1, 1] },
   // 右手系 Y Up → X軸周りに +90° 回転して Y→Z へ
-  'RIGHT_HANDED_Y_UP': { rotation: [Math.PI / 2, 0, 0], scale: [1, 1, 1] },
+  RIGHT_HANDED_Y_UP: { rotation: [Math.PI / 2, 0, 0], scale: [1, 1, 1] },
   // 右手系 X Up → Y軸周りに -90° 回転して X→Z へ
-  'RIGHT_HANDED_X_UP': { rotation: [0, -Math.PI / 2, 0], scale: [1, 1, 1] },
+  RIGHT_HANDED_X_UP: { rotation: [0, -Math.PI / 2, 0], scale: [1, 1, 1] },
   // 左手系 Z Up → X軸ミラーで右手系に変換
-  'LEFT_HANDED_Z_UP': { rotation: [0, 0, 0], scale: [-1, 1, 1] },
+  LEFT_HANDED_Z_UP: { rotation: [0, 0, 0], scale: [-1, 1, 1] },
   // 左手系 Y Up → X軸周りに +90° 回転 + X軸ミラー
-  'LEFT_HANDED_Y_UP': { rotation: [Math.PI / 2, 0, 0], scale: [-1, 1, 1] },
+  LEFT_HANDED_Y_UP: { rotation: [Math.PI / 2, 0, 0], scale: [-1, 1, 1] },
   // 左手系 X Up → Y軸周りに -90° 回転 + X軸ミラー
-  'LEFT_HANDED_X_UP': { rotation: [0, -Math.PI / 2, 0], scale: [-1, 1, 1] },
+  LEFT_HANDED_X_UP: { rotation: [0, -Math.PI / 2, 0], scale: [-1, 1, 1] },
 };
 
 export type ContractFileProps = {
@@ -48,7 +51,7 @@ export type ContractFileProps = {
   referencePoint?: Vector3;
   selected?: boolean;
   translation: { x: number; y: number; z: number };
-  rotation: { x: number; y: number; z: number };  // degree
+  rotation: { x: number; y: number; z: number }; // degree
   inspectorPointSize?: number;
   inspectorOpacity?: number;
   inspectorCoordinateSystem?: CoordinateSystemType;
@@ -249,7 +252,17 @@ const ContractFileView = ({
     if (inspectorPointSize === undefined && inspectorOpacity === undefined) return;
 
     group.traverse((obj: Object3D) => {
-      const mat = (obj as { material?: { size?: number; uniforms?: Record<string, { value?: number }>; opacity?: number; transparent?: boolean; needsUpdate?: boolean } }).material;
+      const mat = (
+        obj as {
+          material?: {
+            size?: number;
+            uniforms?: Record<string, { value?: number }>;
+            opacity?: number;
+            transparent?: boolean;
+            needsUpdate?: boolean;
+          };
+        }
+      ).material;
       if (!mat) return;
 
       if (inspectorPointSize !== undefined) {
@@ -295,11 +308,20 @@ const ContractFileView = ({
         rotation.x * (Math.PI / 180),
         rotation.y * (Math.PI / 180),
         rotation.z * (Math.PI / 180),
-        'XYZ'
+        "XYZ",
       ]}
     >
       <group
-        rotation={csTransform ? new Euler(csTransform.rotation[0], csTransform.rotation[1], csTransform.rotation[2], 'XYZ') : undefined}
+        rotation={
+          csTransform
+            ? new Euler(
+                csTransform.rotation[0],
+                csTransform.rotation[1],
+                csTransform.rotation[2],
+                "XYZ"
+              )
+            : undefined
+        }
         scale={csTransform ? csTransform.scale : undefined}
       >
         <PointCloud

--- a/src/components/CrossSectionHandler.tsx
+++ b/src/components/CrossSectionHandler.tsx
@@ -1,26 +1,11 @@
-import { Line, PivotControls } from '@react-three/drei';
-import {
-  FC,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
-import {
-  ColorRepresentation,
-  Matrix4,
-  Plane,
-  Quaternion,
-  Vector3,
-} from 'three';
-import { useClippingPlanes } from '../contexts/clippingPlanes';
+import { Line, PivotControls } from "@react-three/drei";
+import { FC, useCallback, useEffect, useMemo, useState } from "react";
+import { ColorRepresentation, Matrix4, Plane, Quaternion, Vector3 } from "three";
+import { useClippingPlanes } from "../contexts/clippingPlanes";
 
 export const CrossSectionHandler: FC = () => {
   const [plane, setPlane] = useState<Plane>(
-    new Plane().setFromNormalAndCoplanarPoint(
-      new Vector3(0, 0, -1),
-      new Vector3()
-    )
+    new Plane().setFromNormalAndCoplanarPoint(new Vector3(0, 0, -1), new Vector3())
   );
   const { setClippingPlanes } = useClippingPlanes();
 
@@ -52,7 +37,7 @@ export const CrossSectionPlane: FC<{
   size: number;
   color?: ColorRepresentation;
   opacity?: number;
-}> = ({ size, color = 'yellow', opacity = 0.85 }) => {
+}> = ({ size, color = "yellow", opacity = 0.85 }) => {
   const rectangle = useMemo(() => {
     const pts = [
       new Vector3(-size / 2, -size / 2, 0),
@@ -64,17 +49,11 @@ export const CrossSectionPlane: FC<{
   }, [size]);
 
   const lt2rb = useMemo(() => {
-    return [
-      new Vector3(-size / 2, -size / 2, 0),
-      new Vector3(size / 2, size / 2, 0),
-    ];
+    return [new Vector3(-size / 2, -size / 2, 0), new Vector3(size / 2, size / 2, 0)];
   }, [size]);
 
   const rt2lb = useMemo(() => {
-    return [
-      new Vector3(size / 2, -size / 2, 0),
-      new Vector3(-size / 2, size / 2, 0),
-    ];
+    return [new Vector3(size / 2, -size / 2, 0), new Vector3(-size / 2, size / 2, 0)];
   }, [size]);
 
   return (
@@ -85,4 +64,3 @@ export const CrossSectionPlane: FC<{
     </group>
   );
 };
-

--- a/src/components/FileUploadModal.tsx
+++ b/src/components/FileUploadModal.tsx
@@ -1,12 +1,5 @@
 import { Add } from "@mui/icons-material";
-import {
-  Box,
-  Button,
-  FormControl,
-  FormHelperText,
-  FormLabel,
-  Typography,
-} from "@mui/material";
+import { Box, Button, FormControl, FormHelperText, FormLabel, Typography } from "@mui/material";
 import React, { FC, useCallback, useMemo, useRef, useState } from "react";
 import { useClient } from "../contexts/client";
 import { ModalBox, ModalBoxProps } from "./ModalBox";
@@ -15,9 +8,7 @@ import { RCDEClient } from "../lib/rcde-client";
 
 export type FileUploadModalProps = {
   contractId: number;
-  onUploaded?: (
-    res: Awaited<ReturnType<RCDEClient["uploadContractFile"]>>
-  ) => void;
+  onUploaded?: (res: Awaited<ReturnType<RCDEClient["uploadContractFile"]>>) => void;
 } & Omit<ModalBoxProps, "children">;
 
 const FileUploadModal: FC<FileUploadModalProps> = (props) => {
@@ -28,28 +19,24 @@ const FileUploadModal: FC<FileUploadModalProps> = (props) => {
   const [file, setFile] = useState<File | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>("");
-  const [pointCloudAttribute, setPointCloudAttribute] =
-    useState<PointCloudAttribute>({});
+  const [pointCloudAttribute, setPointCloudAttribute] = useState<PointCloudAttribute>({});
 
   const accept = useMemo(() => {
     return ".las,.laz,.csv,.txt,.xyz,.e57";
   }, []);
 
-  const handleChangeFile = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const { files: fileList } = event.target;
-      if (fileList !== null) {
-        const inputFiles = Array.from(fileList);
-        if (inputFiles.length > 10) {
-          setErrorMessage("アップロードできるファイル数は10個までです");
-          return;
-        }
-        setErrorMessage("");
-        setFile(inputFiles[0]);
+  const handleChangeFile = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const { files: fileList } = event.target;
+    if (fileList !== null) {
+      const inputFiles = Array.from(fileList);
+      if (inputFiles.length > 10) {
+        setErrorMessage("アップロードできるファイル数は10個までです");
+        return;
       }
-    },
-    []
-  );
+      setErrorMessage("");
+      setFile(inputFiles[0]);
+    }
+  }, []);
 
   const handleUpload = useCallback(() => {
     if (file !== null) {
@@ -168,11 +155,7 @@ const FileUploadModal: FC<FileUploadModalProps> = (props) => {
                 textAlign: "right",
               }}
             >
-              <Button
-                variant="contained"
-                onClick={handleUpload}
-                disabled={file === null}
-              >
+              <Button variant="contained" onClick={handleUpload} disabled={file === null}>
                 アップロードする
               </Button>
             </Box>

--- a/src/components/MeasurementHandler.tsx
+++ b/src/components/MeasurementHandler.tsx
@@ -1,10 +1,10 @@
-import { useFrame, useThree } from '@react-three/fiber';
-import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { BufferGeometry, Matrix4, Points, Scene, Vector3 } from 'three';
-import { buildTree, pick } from '../services/Picking';
-import { useMouseUVPosition } from '../hooks/useMouseUVPosition';
-import { MeasurementView } from './MeasurementView';
-import { useReferencePoint } from '../contexts/referencePoint';
+import { useFrame, useThree } from "@react-three/fiber";
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { BufferGeometry, Matrix4, Points, Scene, Vector3 } from "three";
+import { buildTree, pick } from "../services/Picking";
+import { useMouseUVPosition } from "../hooks/useMouseUVPosition";
+import { MeasurementView } from "./MeasurementView";
+import { useReferencePoint } from "../contexts/referencePoint";
 
 export type MeasurementHandlerProps = {
   onChange?: (points: Vector3[]) => void;
@@ -18,18 +18,14 @@ const extractPointsFromScene = (scene: Scene, sampleRate = 10): Vector3[] => {
 
   scene.traverse((obj) => {
     // Points オブジェクト、または type が 'Points' または 'points' のオブジェクトを検索
-    if (obj instanceof Points || obj.type === 'Points' || obj.type === 'points') {
+    if (obj instanceof Points || obj.type === "Points" || obj.type === "points") {
       const geometry = (obj as Points).geometry as BufferGeometry;
-      const positions = geometry.getAttribute('position');
+      const positions = geometry.getAttribute("position");
 
       if (positions) {
         // パフォーマンスのためサンプリング
         for (let i = 0; i < positions.count; i += sampleRate) {
-          const point = new Vector3(
-            positions.getX(i),
-            positions.getY(i),
-            positions.getZ(i)
-          );
+          const point = new Vector3(positions.getX(i), positions.getY(i), positions.getZ(i));
           // ワールド座標に変換
           point.applyMatrix4(obj.matrixWorld);
           allPoints.push(point);
@@ -47,7 +43,7 @@ const MeasurementHandler: FC<MeasurementHandlerProps> = ({ onChange, externalApp
   // ローカルstateを使用（R3F Context問題を回避）
   const [points, setPoints] = useState<Vector3[]>([]);
   useReferencePoint(); // コンテキスト接続を維持
-  const treeRef = useRef<ReturnType<typeof buildTree>['tree'] | null>(null);
+  const treeRef = useRef<ReturnType<typeof buildTree>["tree"] | null>(null);
   const pointsRef = useRef<Vector3[]>([]);
   const prevCameraMatrix = useRef<Matrix4>(new Matrix4());
 
@@ -97,17 +93,14 @@ const MeasurementHandler: FC<MeasurementHandlerProps> = ({ onChange, externalApp
     return () => clearTimeout(timer);
   }, [camera, scene]);
 
-  const pickPoint = useCallback(
-    (uv: { x: number; y: number }): Vector3 | undefined => {
-      if (!treeRef.current || pointsRef.current.length === 0) {
-        return undefined;
-      }
+  const pickPoint = useCallback((uv: { x: number; y: number }): Vector3 | undefined => {
+    if (!treeRef.current || pointsRef.current.length === 0) {
+      return undefined;
+    }
 
-      const pickedPoint = pick(uv, treeRef.current, pointsRef.current);
-      return pickedPoint;
-    },
-    []
-  );
+    const pickedPoint = pick(uv, treeRef.current, pointsRef.current);
+    return pickedPoint;
+  }, []);
 
   useEffect(() => {
     const handleMouseDown = (e: MouseEvent) => {
@@ -141,7 +134,7 @@ const MeasurementHandler: FC<MeasurementHandlerProps> = ({ onChange, externalApp
     };
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
+      if (e.key === "Escape") {
         setPoints([]);
         setHead(null);
         lastRef.current = null;
@@ -163,27 +156,22 @@ const MeasurementHandler: FC<MeasurementHandlerProps> = ({ onChange, externalApp
     };
 
     // capture: true でイベントを先に捕捉
-    canvas.addEventListener('mousedown', handleMouseDown, { capture: true });
-    canvas.addEventListener('click', handleClick, { capture: true });
-    canvas.addEventListener('mousemove', handleMouseMove);
-    window.addEventListener('keydown', handleKeyDown);
-    canvas.addEventListener('contextmenu', handleContextMenu, { capture: true });
+    canvas.addEventListener("mousedown", handleMouseDown, { capture: true });
+    canvas.addEventListener("click", handleClick, { capture: true });
+    canvas.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("keydown", handleKeyDown);
+    canvas.addEventListener("contextmenu", handleContextMenu, { capture: true });
 
     return () => {
-      canvas.removeEventListener('mousedown', handleMouseDown, { capture: true });
-      canvas.removeEventListener('click', handleClick, { capture: true });
-      canvas.removeEventListener('mousemove', handleMouseMove);
-      window.removeEventListener('keydown', handleKeyDown);
-      canvas.removeEventListener('contextmenu', handleContextMenu, { capture: true });
+      canvas.removeEventListener("mousedown", handleMouseDown, { capture: true });
+      canvas.removeEventListener("click", handleClick, { capture: true });
+      canvas.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("keydown", handleKeyDown);
+      canvas.removeEventListener("contextmenu", handleContextMenu, { capture: true });
     };
   }, [canvas, getUV, pickPoint, points, setPoints, onChange]);
 
-  return (
-    <MeasurementView
-      edit
-      points={displayPoints}
-    />
-  );
+  return <MeasurementView edit points={displayPoints} />;
 };
 
 export { MeasurementHandler };

--- a/src/components/MeasurementView.tsx
+++ b/src/components/MeasurementView.tsx
@@ -1,8 +1,8 @@
-import { Html } from '@react-three/drei';
-import { useFrame, useThree } from '@react-three/fiber';
-import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Camera, Matrix4, Vector2, Vector3 } from 'three';
-import { RAD2DEG } from 'three/src/math/MathUtils.js';
+import { Html } from "@react-three/drei";
+import { useFrame, useThree } from "@react-three/fiber";
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Camera, Matrix4, Vector2, Vector3 } from "three";
+import { RAD2DEG } from "three/src/math/MathUtils.js";
 
 type MeasurementViewProps = {
   points?: Vector3[];
@@ -10,22 +10,18 @@ type MeasurementViewProps = {
   edit?: boolean;
 };
 
-const getViewMetricPoints = (
-  div: HTMLDivElement,
-  camera: Camera,
-  point: Vector3
-): Vector3 => {
+const getViewMetricPoints = (div: HTMLDivElement, camera: Camera, point: Vector3): Vector3 => {
   const { width, height } = div.getBoundingClientRect();
   const projection = point.clone().project(camera);
-  const screenPos = new Vector3(((projection.x + 1) / 2) * width, (-(projection.y - 1) / 2) * height, 0);
+  const screenPos = new Vector3(
+    ((projection.x + 1) / 2) * width,
+    (-(projection.y - 1) / 2) * height,
+    0
+  );
   return screenPos;
 };
 
-const MeasurementView: FC<MeasurementViewProps> = ({
-  points,
-  referencePoint,
-  edit,
-}) => {
+const MeasurementView: FC<MeasurementViewProps> = ({ points, referencePoint, edit }) => {
   const { camera } = useThree();
   const [div, setDiv] = useState<HTMLDivElement | null>(null);
 
@@ -39,7 +35,7 @@ const MeasurementView: FC<MeasurementViewProps> = ({
   >([]);
   const prev = useRef<Matrix4>(new Matrix4());
   const prevPtsLength = useRef(0);
-  const prevPointsHash = useRef<string>('');
+  const prevPointsHash = useRef<string>("");
 
   const memoCachedPoints = useMemo(() => {
     if (points !== undefined) {
@@ -69,18 +65,16 @@ const MeasurementView: FC<MeasurementViewProps> = ({
         setEditMetricPoints(viewPoints);
       }
 
-      const viewMetrics = Array.from(Array(viewPoints.length - 1).keys()).map(
-        (i) => {
-          const p0 = transformedPoints[i];
-          const p1 = transformedPoints[i + 1];
-          const length = p0.distanceTo(p1);
-          return {
-            from: viewPoints[i],
-            to: viewPoints[i + 1],
-            length,
-          };
-        }
-      );
+      const viewMetrics = Array.from(Array(viewPoints.length - 1).keys()).map((i) => {
+        const p0 = transformedPoints[i];
+        const p1 = transformedPoints[i + 1];
+        const length = p0.distanceTo(p1);
+        return {
+          from: viewPoints[i],
+          to: viewPoints[i + 1],
+          length,
+        };
+      });
       setMetrics(viewMetrics);
     },
     [div, edit, offset, memoCachedPoints]
@@ -98,8 +92,11 @@ const MeasurementView: FC<MeasurementViewProps> = ({
 
     // 座標値のハッシュを計算（点数が同じでも座標値が変わったら検知）
     const currentHash = memoCachedPoints
-      .map((memoCachedPoint) => `${memoCachedPoint.x.toFixed(3)},${memoCachedPoint.y.toFixed(3)},${memoCachedPoint.z.toFixed(3)}`)
-      .join('|');
+      .map(
+        (memoCachedPoint) =>
+          `${memoCachedPoint.x.toFixed(3)},${memoCachedPoint.y.toFixed(3)},${memoCachedPoint.z.toFixed(3)}`
+      )
+      .join("|");
     const coordsChanged = prevPointsHash.current !== currentHash;
 
     if ((!prev.current.equals(camera.matrixWorld) || ptsChanged || coordsChanged) && div !== null) {
@@ -116,19 +113,13 @@ const MeasurementView: FC<MeasurementViewProps> = ({
       ref={setDiv}
       fullscreen
       style={{
-        pointerEvents: 'none',
-        userSelect: 'none',
+        pointerEvents: "none",
+        userSelect: "none",
       }}
       zIndexRange={[0, 100]}
     >
       {editMetricPoints.map((point, idx) => {
-        return (
-          <MeasurementPoint
-            key={`metrics-point-${idx}`}
-            position={point}
-            color="white"
-          />
-        );
+        return <MeasurementPoint key={`metrics-point-${idx}`} position={point} color="white" />;
       })}
       {metrics.map((item, idx) => {
         return <MeasurementLine key={`metrics-line-${idx}`} {...item} />;
@@ -144,23 +135,17 @@ const MeasurementPoint: FC<{
   return (
     <div
       style={{
-        position: 'absolute',
-        left: '0px',
-        right: '0px',
-        top: '0px',
-        bottom: '0px',
-        pointerEvents: 'none',
-        overflow: 'hidden',
+        position: "absolute",
+        left: "0px",
+        right: "0px",
+        top: "0px",
+        bottom: "0px",
+        pointerEvents: "none",
+        overflow: "hidden",
       }}
     >
       <svg width="100%" height="100%">
-        <circle
-          cx={position.x}
-          cy={position.y}
-          r={5}
-          fill={color}
-          stroke="black"
-        />
+        <circle cx={position.x} cy={position.y} r={5} fill={color} stroke="black" />
       </svg>
     </div>
   );
@@ -186,8 +171,7 @@ const MeasurementLine: FC<{
     const arrowBodyLengthMax = 40;
     const opacity = Math.min(
       1,
-      (dirLength - arrowBodyLengthMin) /
-        (arrowBodyLengthMax - arrowBodyLengthMin)
+      (dirLength - arrowBodyLengthMin) / (arrowBodyLengthMax - arrowBodyLengthMin)
     );
 
     const left = normalizedDirection
@@ -229,63 +213,38 @@ const MeasurementLine: FC<{
   return (
     <div
       style={{
-        position: 'absolute',
-        left: '0px',
-        right: '0px',
-        top: '0px',
-        bottom: '0px',
-        pointerEvents: 'none',
-        overflow: 'hidden',
+        position: "absolute",
+        left: "0px",
+        right: "0px",
+        top: "0px",
+        bottom: "0px",
+        pointerEvents: "none",
+        overflow: "hidden",
       }}
     >
       <svg width="100%" height="100%">
         <g
           style={{
-            stroke: 'black',
+            stroke: "black",
             strokeWidth: 2,
           }}
         >
-          <line
-            x1={data.head.x}
-            y1={data.head.y}
-            x2={data.tail.x}
-            y2={data.tail.y}
-          />
-          <line
-            x1={data.head.x}
-            y1={data.head.y}
-            x2={data.headLeft.x}
-            y2={data.headLeft.y}
-          />
-          <line
-            x1={data.head.x}
-            y1={data.head.y}
-            x2={data.headRight.x}
-            y2={data.headRight.y}
-          />
-          <line
-            x1={data.tail.x}
-            y1={data.tail.y}
-            x2={data.tailLeft.x}
-            y2={data.tailLeft.y}
-          />
-          <line
-            x1={data.tail.x}
-            y1={data.tail.y}
-            x2={data.tailRight.x}
-            y2={data.tailRight.y}
-          />
+          <line x1={data.head.x} y1={data.head.y} x2={data.tail.x} y2={data.tail.y} />
+          <line x1={data.head.x} y1={data.head.y} x2={data.headLeft.x} y2={data.headLeft.y} />
+          <line x1={data.head.x} y1={data.head.y} x2={data.headRight.x} y2={data.headRight.y} />
+          <line x1={data.tail.x} y1={data.tail.y} x2={data.tailLeft.x} y2={data.tailLeft.y} />
+          <line x1={data.tail.x} y1={data.tail.y} x2={data.tailRight.x} y2={data.tailRight.y} />
         </g>
       </svg>
       <span
         style={{
-          position: 'absolute',
+          position: "absolute",
           left: `${data.labelPosition.x}px`,
           top: `${data.labelPosition.y}px`,
           transform: `translate(-50%, -50%) rotate(${data.angle}deg)`,
-          color: 'black',
-          fontSize: '14px',
-          fontWeight: 'bold',
+          color: "black",
+          fontSize: "14px",
+          fontWeight: "bold",
         }}
       >
         {length.toFixed(2)}m

--- a/src/components/PointCloudAttributeForm.tsx
+++ b/src/components/PointCloudAttributeForm.tsx
@@ -17,11 +17,7 @@ export type PointCloudAttributeFormProps = {
   onChange?: (params: OnChangeParams) => void;
 };
 
-const PointCloudAttributeForm = ({
-  value,
-  onChange,
-}: PointCloudAttributeFormProps) => {
-
+const PointCloudAttributeForm = ({ value, onChange }: PointCloudAttributeFormProps) => {
   const formItems: FormItem[] = useMemo(
     () => [
       {
@@ -53,10 +49,7 @@ const PointCloudAttributeForm = ({
   );
 
   const handleChange = useCallback(
-    (
-      event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-      key: FormItemKey
-    ) => {
+    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>, key: FormItemKey) => {
       onChange?.({
         key,
         value: event.target.value,

--- a/src/components/RCDE.tsx
+++ b/src/components/RCDE.tsx
@@ -7,7 +7,7 @@ import { Viewer, ViewerProps } from "./Viewer";
 
 /**
  * Root component for RCDE
- * 
+ *
  * @example
  * ```tsx
  * <RCDE constructionId={1} contractId={1} app={app}>

--- a/src/components/ReferencePointAxis.tsx
+++ b/src/components/ReferencePointAxis.tsx
@@ -1,5 +1,5 @@
-import { FC, useMemo } from 'react';
-import { Vector3 } from 'three';
+import { FC, useMemo } from "react";
+import { Vector3 } from "three";
 
 /**
  * Reference point axis component props
@@ -56,9 +56,9 @@ const ReferencePointAxis: FC<ReferencePointAxisProps> = ({
   // Define axis directions and colors
   const axes = useMemo(
     () => [
-      { direction: new Vector3(1, 0, 0), color: '#ff0000', label: 'X' }, // Red for X
-      { direction: new Vector3(0, 1, 0), color: '#00ff00', label: 'Y' }, // Green for Y
-      { direction: new Vector3(0, 0, 1), color: '#0000ff', label: 'Z' }, // Blue for Z
+      { direction: new Vector3(1, 0, 0), color: "#ff0000", label: "X" }, // Red for X
+      { direction: new Vector3(0, 1, 0), color: "#00ff00", label: "Y" }, // Green for Y
+      { direction: new Vector3(0, 0, 1), color: "#0000ff", label: "Z" }, // Blue for Z
     ],
     []
   );

--- a/src/components/ReferencePointView.tsx
+++ b/src/components/ReferencePointView.tsx
@@ -1,5 +1,5 @@
-import { Box, Typography } from '@mui/material';
-import { FC } from 'react';
+import { Box, Typography } from "@mui/material";
+import { FC } from "react";
 
 export type ReferencePointViewProps = {
   point: {
@@ -14,25 +14,25 @@ const ReferencePointView: FC<ReferencePointViewProps> = ({ point }) => {
     <Box
       component="div"
       sx={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        alignContent: 'center',
-        pointerEvents: 'none',
-        userSelect: 'none',
+        display: "inline-flex",
+        alignItems: "center",
+        alignContent: "center",
+        pointerEvents: "none",
+        userSelect: "none",
       }}
     >
       <Typography
         variant="caption"
         sx={{
           marginRight: 1,
-          marginTop: '2px',
+          marginTop: "2px",
         }}
       >
         基準点
       </Typography>
       <code
         style={{
-          fontSize: '0.75em',
+          fontSize: "0.75em",
         }}
       >
         ({truncate(point.x)}, {truncate(point.y)}, {truncate(point.z)})

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -1,14 +1,20 @@
 import { Box } from "@mui/material";
-import {
-  GizmoHelper,
-  GizmoViewport,
-  Grid,
-  MapControls,
-} from "@react-three/drei";
+import { GizmoHelper, GizmoViewport, Grid, MapControls } from "@react-three/drei";
 import { Canvas, CanvasProps, useThree } from "@react-three/fiber";
 import { PointCloudMeta } from "@i-con/pcd-viewer";
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Box3, Color, DoubleSide, Quaternion, Vector2, Vector3, Group, PerspectiveCamera, Object3D, Raycaster } from "three";
+import {
+  Box3,
+  Color,
+  DoubleSide,
+  Quaternion,
+  Vector2,
+  Vector3,
+  Group,
+  PerspectiveCamera,
+  Object3D,
+  Raycaster,
+} from "three";
 import { useClient } from "../contexts/client";
 import { ContractFile, useContractFiles } from "../contexts/contractFiles";
 import { useReferencePoint } from "../contexts/referencePoint";
@@ -17,15 +23,15 @@ import { LeftSider } from "./LeftSider";
 import { ReferencePointView } from "./ReferencePointView";
 import { RightSider } from "./right/RightSider";
 
-type UpAxis = 'Y' | 'Z';
+type UpAxis = "Y" | "Z";
 
 type CoordinateSystemType =
-  | 'RIGHT_HANDED_X_UP'
-  | 'LEFT_HANDED_X_UP'
-  | 'RIGHT_HANDED_Y_UP'
-  | 'LEFT_HANDED_Y_UP'
-  | 'RIGHT_HANDED_Z_UP'
-  | 'LEFT_HANDED_Z_UP';
+  | "RIGHT_HANDED_X_UP"
+  | "LEFT_HANDED_X_UP"
+  | "RIGHT_HANDED_Y_UP"
+  | "LEFT_HANDED_Y_UP"
+  | "RIGHT_HANDED_Z_UP"
+  | "LEFT_HANDED_Z_UP";
 
 type ViewerTransform = {
   translation: { x: number; y: number; z: number };
@@ -34,16 +40,16 @@ type ViewerTransform = {
 };
 type ViewerAppearance = {
   pointSize: number; // 0..5
-  opacity: number;   // 0..100
-  upAxis?: UpAxis;   // カメラUp
+  opacity: number; // 0..100
+  upAxis?: UpAxis; // カメラUp
   coordinateSystem?: CoordinateSystemType; // ファイル単位の座標系
-  fileId?: number;   // R-CDEのデータベースに登録されているファイルID
+  fileId?: number; // R-CDEのデータベースに登録されているファイルID
 };
 type Command =
-  | { type: 'SET_TRANSFORM'; payload: ViewerTransform }
-  | { type: 'SET_APPEARANCE'; payload: ViewerAppearance }
-  | { type: 'RESET' };
-const CHANNEL = 'RCDE_VIEWER_CMD';
+  | { type: "SET_TRANSFORM"; payload: ViewerTransform }
+  | { type: "SET_APPEARANCE"; payload: ViewerAppearance }
+  | { type: "RESET" };
+const CHANNEL = "RCDE_VIEWER_CMD";
 
 type R3FProps = {
   canvas?: CanvasProps;
@@ -56,7 +62,7 @@ type R3FProps = {
 export type RCDEAppConfig = {
   token: string;
   baseUrl?: string;
-  authType?: '2legged' | '3legged';
+  authType?: "2legged" | "3legged";
 };
 
 export type ViewerProps = {
@@ -76,7 +82,10 @@ export type ViewerProps = {
 const clamp = (v: number, min: number, max: number) => Math.min(max, Math.max(min, v));
 
 // Helper function to check if a ray intersects with a Box3
-const rayIntersectBox = (ray: { origin: Vector3; direction: Vector3 }, box: Box3): Vector3 | null => {
+const rayIntersectBox = (
+  ray: { origin: Vector3; direction: Vector3 },
+  box: Box3
+): Vector3 | null => {
   const invDir = new Vector3(1 / ray.direction.x, 1 / ray.direction.y, 1 / ray.direction.z);
   const t1 = (box.min.x - ray.origin.x) * invDir.x;
   const t2 = (box.max.x - ray.origin.x) * invDir.x;
@@ -105,45 +114,51 @@ const ClickHandler: FC<{
   const { camera, gl } = useThree();
   const raycaster = useMemo(() => new Raycaster(), []);
 
-  const handleClick = useCallback((event: MouseEvent) => {
-    if (!onContractFileClick) return;
+  const handleClick = useCallback(
+    (event: MouseEvent) => {
+      if (!onContractFileClick) return;
 
-    const rect = gl.domElement.getBoundingClientRect();
-    const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
-    const y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+      const rect = gl.domElement.getBoundingClientRect();
+      const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+      const y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
 
-    raycaster.setFromCamera(new Vector2(x, y), camera);
-    const ray = raycaster.ray;
+      raycaster.setFromCamera(new Vector2(x, y), camera);
+      const ray = raycaster.ray;
 
-    // Find the closest bounding box that intersects with the ray
-    let closestIntersection: { view: ContractFileProps & { boundingBox: Box3 }; distance: number } | null = null;
+      // Find the closest bounding box that intersects with the ray
+      let closestIntersection: {
+        view: ContractFileProps & { boundingBox: Box3 };
+        distance: number;
+      } | null = null;
 
-    for (const view of views) {
-      // Apply reference point offset to bounding box
-      const offsetBoundingBox = view.boundingBox.clone();
-      offsetBoundingBox.translate(referencePoint);
+      for (const view of views) {
+        // Apply reference point offset to bounding box
+        const offsetBoundingBox = view.boundingBox.clone();
+        offsetBoundingBox.translate(referencePoint);
 
-      const intersection = rayIntersectBox(ray, offsetBoundingBox);
-      if (intersection) {
-        const distance = ray.origin.distanceTo(intersection);
-        if (!closestIntersection || distance < closestIntersection.distance) {
-          closestIntersection = { view, distance };
+        const intersection = rayIntersectBox(ray, offsetBoundingBox);
+        if (intersection) {
+          const distance = ray.origin.distanceTo(intersection);
+          if (!closestIntersection || distance < closestIntersection.distance) {
+            closestIntersection = { view, distance };
+          }
         }
       }
-    }
 
-    if (closestIntersection) {
-      onContractFileClick(closestIntersection.view.file, closestIntersection.view.boundingBox);
-    } else {
-      onContractFileClick(undefined, undefined);
-    }
-  }, [views, referencePoint, onContractFileClick, camera, gl, raycaster]);
+      if (closestIntersection) {
+        onContractFileClick(closestIntersection.view.file, closestIntersection.view.boundingBox);
+      } else {
+        onContractFileClick(undefined, undefined);
+      }
+    },
+    [views, referencePoint, onContractFileClick, camera, gl, raycaster]
+  );
 
   useEffect(() => {
     const canvas = gl.domElement;
-    canvas.addEventListener('click', handleClick);
+    canvas.addEventListener("click", handleClick);
     return () => {
-      canvas.removeEventListener('click', handleClick);
+      canvas.removeEventListener("click", handleClick);
     };
   }, [gl, handleClick]);
 
@@ -152,7 +167,19 @@ const ClickHandler: FC<{
 
 const Viewer: FC<ViewerProps> = (props) => {
   const { load, containers } = useContractFiles();
-  const { app, constructionId, contractId, contractFileIds, r3f, children, positionOffsetComponent, showLeftSider = true, showRightSider = true, selectedFileId, onContractFileClick } = props;
+  const {
+    app,
+    constructionId,
+    contractId,
+    contractFileIds,
+    r3f,
+    children,
+    positionOffsetComponent,
+    showLeftSider = true,
+    showRightSider = true,
+    selectedFileId,
+    onContractFileClick,
+  } = props;
   const { initialize, client, project, setProject } = useClient();
   const { point, change: changeReferencePoint } = useReferencePoint();
   const [views, setViews] = useState<(ContractFileProps & { boundingBox: Box3 })[]>([]);
@@ -168,17 +195,27 @@ const Viewer: FC<ViewerProps> = (props) => {
   });
 
   // File-specific transforms (fileId -> translation + rotation)
-  const [fileTransforms, setFileTransforms] = useState<Record<number, {
-    translation: { x: number; y: number; z: number };
-    rotation: { x: number; y: number; z: number };
-  }>>({});
+  const [fileTransforms, setFileTransforms] = useState<
+    Record<
+      number,
+      {
+        translation: { x: number; y: number; z: number };
+        rotation: { x: number; y: number; z: number };
+      }
+    >
+  >({});
 
   // File-specific appearances (fileId -> pointSize + opacity + coordinateSystem)
-  const [fileAppearances, setFileAppearances] = useState<Record<number, {
-    pointSize: number;
-    opacity: number;
-    coordinateSystem?: CoordinateSystemType;
-  }>>({});
+  const [fileAppearances, setFileAppearances] = useState<
+    Record<
+      number,
+      {
+        pointSize: number;
+        opacity: number;
+        coordinateSystem?: CoordinateSystemType;
+      }
+    >
+  >({});
 
   // Memoize contractFileIds to prevent unnecessary re-renders
   // Use JSON.stringify to compare array contents rather than reference
@@ -190,7 +227,9 @@ const Viewer: FC<ViewerProps> = (props) => {
     initialize(app);
   }, [app, initialize]);
 
-  useEffect(() => { setProject({ constructionId, contractId }); }, [constructionId, contractId, setProject]);
+  useEffect(() => {
+    setProject({ constructionId, contractId });
+  }, [constructionId, contractId, setProject]);
 
   const fetchContractFiles = useCallback(async () => {
     if (!client || !contractId) return;
@@ -211,13 +250,16 @@ const Viewer: FC<ViewerProps> = (props) => {
     }
   }, [client, contractId, fetchContractFiles]);
 
-  const camera = useMemo(() => ({
-    fov: 40,
-    position: new Vector3(1, 2, 1).multiplyScalar(1e2),
-    up: new Vector3(0, 0, 1),
-    near: 1e-1,
-    far: 1e3 * 5,
-  }), []);
+  const camera = useMemo(
+    () => ({
+      fov: 40,
+      position: new Vector3(1, 2, 1).multiplyScalar(1e2),
+      up: new Vector3(0, 0, 1),
+      near: 1e-1,
+      far: 1e3 * 5,
+    }),
+    []
+  );
 
   useEffect(() => {
     if (project === undefined) return;
@@ -231,7 +273,10 @@ const Viewer: FC<ViewerProps> = (props) => {
           .then((d) => {
             const meta = d as unknown as PointCloudMeta;
             const { min, max } = meta.bounds;
-            const boundingBox = new Box3(new Vector3().fromArray(min), new Vector3().fromArray(max));
+            const boundingBox = new Box3(
+              new Vector3().fromArray(min),
+              new Vector3().fromArray(max)
+            );
             return { file: c.file, meta, boundingBox };
           })
           .catch((e) => {
@@ -245,40 +290,60 @@ const Viewer: FC<ViewerProps> = (props) => {
     });
   }, [containers, project, client]);
 
-  const handleFileFocus = useCallback((file: ContractFile) => {
-    const view = views.find((v) => v.file.id === file.id);
-    if (!view) return;
-    const center = view.boundingBox.getCenter(new Vector3());
-    changeReferencePoint(center.negate());
-  }, [views, changeReferencePoint]);
+  const handleFileFocus = useCallback(
+    (file: ContractFile) => {
+      const view = views.find((v) => v.file.id === file.id);
+      if (!view) return;
+      const center = view.boundingBox.getCenter(new Vector3());
+      changeReferencePoint(center.negate());
+    },
+    [views, changeReferencePoint]
+  );
 
-  const handleFileDelete = useCallback((file: ContractFile) => { console.log(file); }, []);
-  const handleUploaded = useCallback(() => { fetchContractFiles(); }, [fetchContractFiles]);
-
-  const applyAppearanceToScene = useCallback((root: Group | null, ps: number, opPercent: number) => {
-    if (!root) return;
-    const pointSize = clamp(ps, 0, 5);
-    const opacity01 = clamp(opPercent, 0, 100) / 100;
-
-    root.traverse((obj: Object3D) => {
-      const mat = (obj as { material?: { size?: number; uniforms?: Record<string, { value?: number }>; opacity?: number; transparent?: boolean; needsUpdate?: boolean } }).material;
-      if (!mat) return;
-
-      if (typeof mat.size === "number") {
-        mat.size = pointSize;
-        mat.needsUpdate = true;
-      }
-      if (mat.uniforms) {
-        if (mat.uniforms.pointSize?.value !== undefined) mat.uniforms.pointSize.value = pointSize;
-        if (mat.uniforms.opacity?.value !== undefined) mat.uniforms.opacity.value = opacity01;
-      }
-      if (typeof mat.opacity === "number") {
-        mat.opacity = opacity01;
-        if (opacity01 < 1 && mat.transparent !== true) mat.transparent = true;
-        mat.needsUpdate = true;
-      }
-    });
+  const handleFileDelete = useCallback((file: ContractFile) => {
+    console.log(file);
   }, []);
+  const handleUploaded = useCallback(() => {
+    fetchContractFiles();
+  }, [fetchContractFiles]);
+
+  const applyAppearanceToScene = useCallback(
+    (root: Group | null, ps: number, opPercent: number) => {
+      if (!root) return;
+      const pointSize = clamp(ps, 0, 5);
+      const opacity01 = clamp(opPercent, 0, 100) / 100;
+
+      root.traverse((obj: Object3D) => {
+        const mat = (
+          obj as {
+            material?: {
+              size?: number;
+              uniforms?: Record<string, { value?: number }>;
+              opacity?: number;
+              transparent?: boolean;
+              needsUpdate?: boolean;
+            };
+          }
+        ).material;
+        if (!mat) return;
+
+        if (typeof mat.size === "number") {
+          mat.size = pointSize;
+          mat.needsUpdate = true;
+        }
+        if (mat.uniforms) {
+          if (mat.uniforms.pointSize?.value !== undefined) mat.uniforms.pointSize.value = pointSize;
+          if (mat.uniforms.opacity?.value !== undefined) mat.uniforms.opacity.value = opacity01;
+        }
+        if (typeof mat.opacity === "number") {
+          mat.opacity = opacity01;
+          if (opacity01 < 1 && mat.transparent !== true) mat.transparent = true;
+          mat.needsUpdate = true;
+        }
+      });
+    },
+    []
+  );
 
   useEffect(() => {
     applyAppearanceToScene(transformRootRef.current, appearance.pointSize, appearance.opacity);
@@ -289,26 +354,26 @@ const Viewer: FC<ViewerProps> = (props) => {
       if (!e?.data || e.data.channel !== CHANNEL) return;
       const cmd = e.data.cmd as Command;
 
-      if (cmd.type === 'SET_TRANSFORM') {
+      if (cmd.type === "SET_TRANSFORM") {
         const { fileId, translation, rotation } = cmd.payload;
         // Store file-specific transform (translation + rotation)
-        setFileTransforms(prev => ({
+        setFileTransforms((prev) => ({
           ...prev,
           [fileId]: {
             translation,
-            rotation
-          }
+            rotation,
+          },
         }));
-      } else if (cmd.type === 'SET_APPEARANCE') {
+      } else if (cmd.type === "SET_APPEARANCE") {
         const up = cmd.payload.upAxis;
         const cs = cmd.payload.coordinateSystem;
         const nextPointSize = clamp(cmd.payload.pointSize ?? appearance.pointSize, 0, 5);
-        const nextOpacity   = clamp(cmd.payload.opacity   ?? appearance.opacity,   0, 100);
+        const nextOpacity = clamp(cmd.payload.opacity ?? appearance.opacity, 0, 100);
 
         // fileId が指定されている場合はファイル単位で保存
         const fileId = cmd.payload.fileId;
         if (fileId !== undefined) {
-          setFileAppearances(prev => ({
+          setFileAppearances((prev) => ({
             ...prev,
             [fileId]: {
               pointSize: nextPointSize,
@@ -325,17 +390,17 @@ const Viewer: FC<ViewerProps> = (props) => {
         if (up) {
           const cam = cameraRef.current;
           if (cam) {
-            if (up === 'Y') cam.up.set(0, 1, 0);
+            if (up === "Y") cam.up.set(0, 1, 0);
             else cam.up.set(0, 0, 1);
             cam.updateProjectionMatrix?.();
           }
           controlsRef.current?.update?.();
         }
-      } else if (cmd.type === 'RESET') {
+      } else if (cmd.type === "RESET") {
         const g = transformRootRef.current;
         if (g) {
           g.position.set(0, 0, 0);
-          g.rotation.set(0, 0, 0, 'XYZ');
+          g.rotation.set(0, 0, 0, "XYZ");
         }
         setAppearance({ pointSize: 2, opacity: 100 });
         setFileAppearances({});
@@ -349,8 +414,8 @@ const Viewer: FC<ViewerProps> = (props) => {
         controlsRef.current?.update?.();
       }
     };
-    window.addEventListener('message', listener);
-    return () => window.removeEventListener('message', listener);
+    window.addEventListener("message", listener);
+    return () => window.removeEventListener("message", listener);
   }, [appearance.pointSize, appearance.opacity]);
 
   return (
@@ -403,7 +468,13 @@ const Viewer: FC<ViewerProps> = (props) => {
             })}
             <group position={point}>{positionOffsetComponent}</group>
             <group>{children}</group>
-            {onContractFileClick && <ClickHandler views={views} referencePoint={point} onContractFileClick={onContractFileClick} />}
+            {onContractFileClick && (
+              <ClickHandler
+                views={views}
+                referencePoint={point}
+                onContractFileClick={onContractFileClick}
+              />
+            )}
           </group>
         </Canvas>
 
@@ -421,7 +492,9 @@ const Viewer: FC<ViewerProps> = (props) => {
           <ReferencePointView point={point} />
         </Box>
       </Box>
-      {showRightSider && <RightSider onFileFocus={handleFileFocus} onFileDelete={handleFileDelete} />}
+      {showRightSider && (
+        <RightSider onFileFocus={handleFileFocus} onFileDelete={handleFileDelete} />
+      )}
     </Box>
   );
 };

--- a/src/components/right/ContractFileList.tsx
+++ b/src/components/right/ContractFileList.tsx
@@ -23,10 +23,7 @@ type ContractFileListProps = {
   onFileDelete: (file: ContractFile) => void;
 };
 
-const ContractFileList: FC<ContractFileListProps> = ({
-  onFileFocus,
-  onFileDelete,
-}) => {
+const ContractFileList: FC<ContractFileListProps> = ({ onFileFocus, onFileDelete }) => {
   const { client, project } = useClient();
   const { toggleVisibility, containers } = useContractFiles();
 
@@ -36,12 +33,9 @@ const ContractFileList: FC<ContractFileListProps> = ({
   } | null>(null);
   const open = focused !== null;
 
-  const handleDetailClick = useCallback(
-    (el: HTMLElement, container: ContractFileContainer) => {
-      setFocused({ el, container });
-    },
-    []
-  );
+  const handleDetailClick = useCallback((el: HTMLElement, container: ContractFileContainer) => {
+    setFocused({ el, container });
+  }, []);
 
   const handleMenuClose = useCallback(() => {
     setFocused(null);

--- a/src/components/right/ReferencePoint.tsx
+++ b/src/components/right/ReferencePoint.tsx
@@ -1,15 +1,8 @@
-import { Close, Save } from '@mui/icons-material';
-import {
-  Box,
-  Button,
-  FormControl,
-  List,
-  ListItem,
-  TextField,
-} from '@mui/material';
-import { ChangeEvent, FC, useCallback } from 'react';
-import { useReferencePoint } from '../../contexts/referencePoint';
-import { GlobalStateContext } from '../../contexts/state';
+import { Close, Save } from "@mui/icons-material";
+import { Box, Button, FormControl, List, ListItem, TextField } from "@mui/material";
+import { ChangeEvent, FC, useCallback } from "react";
+import { useReferencePoint } from "../../contexts/referencePoint";
+import { GlobalStateContext } from "../../contexts/state";
 
 const ReferencePoint: FC = () => {
   const actor = GlobalStateContext.useActorRef();
@@ -100,12 +93,7 @@ const ReferencePoint: FC = () => {
           >
             保存
           </Button>
-          <Button
-            variant="outlined"
-            fullWidth
-            startIcon={<Close />}
-            onClick={handleCloseClick}
-          >
+          <Button variant="outlined" fullWidth startIcon={<Close />} onClick={handleCloseClick}>
             閉じる
           </Button>
         </ListItem>

--- a/src/components/right/RightSider.tsx
+++ b/src/components/right/RightSider.tsx
@@ -23,10 +23,7 @@ const RightSider: FC<RightSiderProps> = ({ onFileFocus, onFileDelete }) => {
       {state.matches("reference_point") ? (
         <ReferencePoint />
       ) : (
-        <ContractFileList
-          onFileFocus={onFileFocus}
-          onFileDelete={onFileDelete}
-        />
+        <ContractFileList onFileFocus={onFileFocus} onFileDelete={onFileDelete} />
       )}
     </MenuList>
   );

--- a/src/contexts/client.tsx
+++ b/src/contexts/client.tsx
@@ -27,17 +27,14 @@ export const ClientProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [client, setClient] = useState<RCDEClient | undefined>();
   const [project, setProject] = useState<ClientContextType["project"]>();
 
-  const initialize = useCallback(
-    (app: RCDEAppConfig) => {
-      const client = new RCDEClient({
-        accessToken: app.token,
-        baseUrl: app.baseUrl,
-        authType: app.authType,
-      });
-      setClient(client);
-    },
-    []
-  );
+  const initialize = useCallback((app: RCDEAppConfig) => {
+    const client = new RCDEClient({
+      accessToken: app.token,
+      baseUrl: app.baseUrl,
+      authType: app.authType,
+    });
+    setClient(client);
+  }, []);
 
   return (
     <ClientContext.Provider value={{ client, initialize, project, setProject }}>

--- a/src/contexts/clippingPlanes.tsx
+++ b/src/contexts/clippingPlanes.tsx
@@ -1,5 +1,13 @@
-import { Dispatch, FC, ReactNode, SetStateAction, createContext, useContext, useState } from 'react';
-import { Plane } from 'three';
+import {
+  Dispatch,
+  FC,
+  ReactNode,
+  SetStateAction,
+  createContext,
+  useContext,
+  useState,
+} from "react";
+import { Plane } from "three";
 
 export type ClippingPlanesContextProps = {
   clippingPlanes: Plane[];
@@ -31,8 +39,7 @@ export const ClippingPlanesProvider: FC<{
 export const useClippingPlanes = (): ClippingPlanesContextProps => {
   const context = useContext(ClippingPlanesContext);
   if (!context) {
-    throw new Error('useClippingPlanes must be used within a ClippingPlanesProvider');
+    throw new Error("useClippingPlanes must be used within a ClippingPlanesProvider");
   }
   return context;
 };
-

--- a/src/contexts/contractFiles.tsx
+++ b/src/contexts/contractFiles.tsx
@@ -1,12 +1,5 @@
 import { RCDEClient } from "../lib/rcde-client";
-import {
-  createContext,
-  FC,
-  ReactNode,
-  useCallback,
-  useContext,
-  useState,
-} from "react";
+import { createContext, FC, ReactNode, useCallback, useContext, useState } from "react";
 
 export type ContractFiles = NonNullable<
   Awaited<ReturnType<RCDEClient["getContractFileList"]>>["contractFiles"]
@@ -24,20 +17,17 @@ type ContractFilesContextType = {
   toggleVisibility: (container: ContractFileContainer) => void;
 };
 
-const ContractFilesContext = createContext<
-  ContractFilesContextType | undefined
->(undefined);
+const ContractFilesContext = createContext<ContractFilesContextType | undefined>(undefined);
 
-export const ContractFilesProvider: FC<{ children: ReactNode }> = ({
-  children,
-}) => {
+export const ContractFilesProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [containers, setContainers] = useState<ContractFileContainer[]>([]);
 
   const load = useCallback((files: ContractFiles, visibleIds?: number[]) => {
     setContainers(
       files.map((file) => ({
         file,
-        visible: visibleIds === undefined ? true : (file.id !== undefined && visibleIds.includes(file.id)),
+        visible:
+          visibleIds === undefined ? true : file.id !== undefined && visibleIds.includes(file.id),
       }))
     );
   }, []);
@@ -56,9 +46,7 @@ export const ContractFilesProvider: FC<{ children: ReactNode }> = ({
   }, []);
 
   return (
-    <ContractFilesContext.Provider
-      value={{ load, toggleVisibility, containers }}
-    >
+    <ContractFilesContext.Provider value={{ load, toggleVisibility, containers }}>
       {children}
     </ContractFilesContext.Provider>
   );
@@ -68,9 +56,7 @@ export const ContractFilesProvider: FC<{ children: ReactNode }> = ({
 export const useContractFiles = (): ContractFilesContextType => {
   const context = useContext(ContractFilesContext);
   if (!context) {
-    throw new Error(
-      "useContractFiles must be used within a ContractFilesProvider"
-    );
+    throw new Error("useContractFiles must be used within a ContractFilesProvider");
   }
   return context;
 };

--- a/src/contexts/measurement.tsx
+++ b/src/contexts/measurement.tsx
@@ -1,5 +1,13 @@
-import { Dispatch, FC, ReactNode, SetStateAction, createContext, useContext, useState } from 'react';
-import { Vector3 } from 'three';
+import {
+  Dispatch,
+  FC,
+  ReactNode,
+  SetStateAction,
+  createContext,
+  useContext,
+  useState,
+} from "react";
+import { Vector3 } from "three";
 
 export type MeasurementContextProps = {
   points: Vector3[];
@@ -36,7 +44,7 @@ export const MeasurementProvider: FC<{ children?: ReactNode }> = ({ children }) 
 export const useMeasurement = (): MeasurementContextProps => {
   const context = useContext(MeasurementContext);
   if (!context) {
-    throw new Error('useMeasurement must be used within a MeasurementProvider');
+    throw new Error("useMeasurement must be used within a MeasurementProvider");
   }
   return context;
 };

--- a/src/contexts/referencePoint.tsx
+++ b/src/contexts/referencePoint.tsx
@@ -22,39 +22,45 @@ export const ReferencePointProvider: FC<{ children: ReactNode }> = ({ children }
   const { client, project } = useClient();
   const { containers } = useContractFiles();
 
-  const change = useCallback((point: Vector3) => {
-    setPoint(point);
-  }, [setPoint]);
+  const change = useCallback(
+    (point: Vector3) => {
+      setPoint(point);
+    },
+    [setPoint]
+  );
 
-  const save = useCallback((point: Vector3) => {
-    setPoint(point);
-  }, [setPoint]);
+  const save = useCallback(
+    (point: Vector3) => {
+      setPoint(point);
+    },
+    [setPoint]
+  );
 
-  const focusFileById = useCallback(async (fileId: number) => {
-    if (!client || !project) return;
+  const focusFileById = useCallback(
+    async (fileId: number) => {
+      if (!client || !project) return;
 
-    // Find the container with the matching file ID
-    const container = containers.find((c) => c.file.id === fileId);
-    if (!container) return;
+      // Find the container with the matching file ID
+      const container = containers.find((c) => c.file.id === fileId);
+      if (!container) return;
 
-    try {
-      // Get file metadata to calculate bounding box
-      const metaData = await client.getContractFileMetadata({
-        ...project,
-        contractFileId: fileId,
-      });
-      const meta = metaData as unknown as PointCloudMeta;
-      const { min, max } = meta.bounds;
-      const boundingBox = new Box3(
-        new Vector3().fromArray(min),
-        new Vector3().fromArray(max)
-      );
-      const center = boundingBox.getCenter(new Vector3());
-      change(center.negate());
-    } catch (err) {
-      console.error("[useReferencePoint] Failed to focus file:", err);
-    }
-  }, [client, project, containers, change]);
+      try {
+        // Get file metadata to calculate bounding box
+        const metaData = await client.getContractFileMetadata({
+          ...project,
+          contractFileId: fileId,
+        });
+        const meta = metaData as unknown as PointCloudMeta;
+        const { min, max } = meta.bounds;
+        const boundingBox = new Box3(new Vector3().fromArray(min), new Vector3().fromArray(max));
+        const center = boundingBox.getCenter(new Vector3());
+        change(center.negate());
+      } catch (err) {
+        console.error("[useReferencePoint] Failed to focus file:", err);
+      }
+    },
+    [client, project, containers, change]
+  );
 
   return (
     <ReferencePointContext.Provider value={{ point, change, save, focusFileById }}>

--- a/src/hooks/useMouseUVPosition.ts
+++ b/src/hooks/useMouseUVPosition.ts
@@ -1,5 +1,5 @@
-import { useCallback } from 'react';
-import { Vector2 } from 'three';
+import { useCallback } from "react";
+import { Vector2 } from "three";
 
 export const useMouseUVPosition = (props: { canvas: HTMLCanvasElement }) => {
   const { canvas } = props;
@@ -8,10 +8,7 @@ export const useMouseUVPosition = (props: { canvas: HTMLCanvasElement }) => {
       const position = new Vector2(e.clientX, e.clientY);
       const { x, y, width, height } = canvas.getBoundingClientRect();
       position.sub(new Vector2(x, y));
-      return new Vector2(
-        (position.x / width) * 2 - 1,
-        -(position.y / height) * 2 + 1
-      );
+      return new Vector2((position.x / width) * 2 - 1, -(position.y / height) * 2 + 1);
     },
     [canvas]
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,33 @@
 export * from "./components/RCDE";
-export * from './bridge/viewerBridge';
-export { RCDEClient, type AuthType, type RCDEClientOptions } from './lib/rcde-client';
-export { Viewer, type RCDEAppConfig, type ViewerProps } from './components/Viewer';
+export * from "./bridge/viewerBridge";
+export { RCDEClient, type AuthType, type RCDEClientOptions } from "./lib/rcde-client";
+export { Viewer, type RCDEAppConfig, type ViewerProps } from "./components/Viewer";
 export { ReferencePointProvider, useReferencePoint } from "./contexts/referencePoint";
 export { ClientProvider, useClient, type ClientContextType } from "./contexts/client";
-export { ContractFilesProvider, useContractFiles, type ContractFiles, type ContractFile, type ContractFileContainer } from "./contexts/contractFiles";
+export {
+  ContractFilesProvider,
+  useContractFiles,
+  type ContractFiles,
+  type ContractFile,
+  type ContractFileContainer,
+} from "./contexts/contractFiles";
 export { GlobalStateContext } from "./contexts/state";
 export { ContractFileView } from "./components/ContractFileView";
 export type { ContractFileProps } from "./components/ContractFileView";
-export { MeasurementProvider, useMeasurement, MeasurementContext, type MeasurementContextProps } from './contexts/measurement';
-export { MeasurementHandler, type MeasurementHandlerProps } from './components/MeasurementHandler';
-export { MeasurementView } from './components/MeasurementView';
+export {
+  MeasurementProvider,
+  useMeasurement,
+  MeasurementContext,
+  type MeasurementContextProps,
+} from "./contexts/measurement";
+export { MeasurementHandler, type MeasurementHandlerProps } from "./components/MeasurementHandler";
+export { MeasurementView } from "./components/MeasurementView";
 export { ReferencePointAxis } from "./components/ReferencePointAxis";
 export type { ReferencePointAxisProps } from "./components/ReferencePointAxis";
-export { CrossSectionHandler, CrossSectionPlane } from './components/CrossSectionHandler';
-export { ClippingPlanesProvider, useClippingPlanes, ClippingPlanesContext, type ClippingPlanesContextProps } from './contexts/clippingPlanes';
+export { CrossSectionHandler, CrossSectionPlane } from "./components/CrossSectionHandler";
+export {
+  ClippingPlanesProvider,
+  useClippingPlanes,
+  ClippingPlanesContext,
+  type ClippingPlanesContextProps,
+} from "./contexts/clippingPlanes";

--- a/src/lib/rcde-client.ts
+++ b/src/lib/rcde-client.ts
@@ -1,4 +1,4 @@
-export type AuthType = '2legged' | '3legged';
+export type AuthType = "2legged" | "3legged";
 
 export type RCDEClientOptions = {
   baseUrl?: string;
@@ -22,29 +22,32 @@ export class RCDEClient {
   private fetchImpl: typeof fetch;
 
   constructor(opts: RCDEClientOptions = {}) {
-    this.baseUrl = opts.baseUrl ?? '';
+    this.baseUrl = opts.baseUrl ?? "";
     this.token = opts.accessToken;
-    this.authType = opts.authType ?? '2legged';
+    this.authType = opts.authType ?? "2legged";
     this.fetchImpl = opts.fetchImpl ?? fetch.bind(globalThis);
   }
 
   private headers(): Record<string, string> {
-    const h: Record<string, string> = { 'Content-Type': 'application/json' };
+    const h: Record<string, string> = { "Content-Type": "application/json" };
     if (this.token) h.Authorization = `Bearer ${this.token}`;
     return h;
   }
 
   private getApiPath(segment: string): string {
-    const prefix = this.authType === '3legged' ? '/ext/v2/userAuthenticated' : '/ext/v2/authenticated';
+    const prefix =
+      this.authType === "3legged" ? "/ext/v2/userAuthenticated" : "/ext/v2/authenticated";
     return `${this.baseUrl}${prefix}${segment}`;
   }
 
   // ---- 既存で使われている想定のAPI ----
 
   // Viewer などで使用
-  async getContractFileList(params: { contractId: number }): Promise<{ contractFiles: ContractFile[] }> {
+  async getContractFileList(params: {
+    contractId: number;
+  }): Promise<{ contractFiles: ContractFile[] }> {
     const { contractId } = params;
-    const url = this.getApiPath('/contractFile');
+    const url = this.getApiPath("/contractFile");
     const queryParams = new URLSearchParams({ contractId: String(contractId) });
     const res = await this.fetchImpl(`${url}?${queryParams}`, {
       headers: this.headers(),
@@ -54,14 +57,17 @@ export class RCDEClient {
     return { contractFiles: data.contractFiles ?? [] };
   }
 
-  async getContractFileMetadata(params: { contractId: number; contractFileId: number }): Promise<Json> {
+  async getContractFileMetadata(params: {
+    contractId: number;
+    contractFileId: number;
+  }): Promise<Json> {
     const { contractId, contractFileId } = params;
-    const url = this.getApiPath('/pclod/meta');
+    const url = this.getApiPath("/pclod/meta");
     const queryParams = new URLSearchParams({
       contractFileId: String(contractFileId),
     });
-    if (this.authType === '2legged') {
-      queryParams.append('contractId', String(contractId));
+    if (this.authType === "2legged") {
+      queryParams.append("contractId", String(contractId));
     }
     const res = await this.fetchImpl(`${url}?${queryParams}`, {
       headers: this.headers(),
@@ -71,16 +77,21 @@ export class RCDEClient {
   }
 
   // 画像（位置）バッファ
-  async getContractFileImagePosition(params: { contractId: number; contractFileId: number; level?: number; addr?: string }): Promise<ArrayBuffer> {
-    const { contractId, contractFileId, level = 0, addr = '0-0-0' } = params;
-    const url = this.getApiPath('/pclod/imagePosition');
+  async getContractFileImagePosition(params: {
+    contractId: number;
+    contractFileId: number;
+    level?: number;
+    addr?: string;
+  }): Promise<ArrayBuffer> {
+    const { contractId, contractFileId, level = 0, addr = "0-0-0" } = params;
+    const url = this.getApiPath("/pclod/imagePosition");
     const queryParams = new URLSearchParams({
       contractFileId: String(contractFileId),
       level: String(level),
       addr,
     });
-    if (this.authType === '2legged') {
-      queryParams.append('contractId', String(contractId));
+    if (this.authType === "2legged") {
+      queryParams.append("contractId", String(contractId));
     }
     const res = await this.fetchImpl(`${url}?${queryParams}`, {
       headers: this.headers(),
@@ -90,16 +101,21 @@ export class RCDEClient {
   }
 
   // 画像（色）バッファ
-  async getContractFileImageColor(params: { contractId: number; contractFileId: number; level?: number; addr?: string }): Promise<ArrayBuffer> {
-    const { contractId, contractFileId, level = 0, addr = '0-0-0' } = params;
-    const url = this.getApiPath('/pclod/imageColor');
+  async getContractFileImageColor(params: {
+    contractId: number;
+    contractFileId: number;
+    level?: number;
+    addr?: string;
+  }): Promise<ArrayBuffer> {
+    const { contractId, contractFileId, level = 0, addr = "0-0-0" } = params;
+    const url = this.getApiPath("/pclod/imageColor");
     const queryParams = new URLSearchParams({
       contractFileId: String(contractFileId),
       level: String(level),
       addr,
     });
-    if (this.authType === '2legged') {
-      queryParams.append('contractId', String(contractId));
+    if (this.authType === "2legged") {
+      queryParams.append("contractId", String(contractId));
     }
     const res = await this.fetchImpl(`${url}?${queryParams}`, {
       headers: this.headers(),
@@ -109,10 +125,13 @@ export class RCDEClient {
   }
 
   // ダウンロードURL
-  async getContractFileDownloadUrl(contractId: number, fileId: number): Promise<{ presignedURL: string; url: string }> {
+  async getContractFileDownloadUrl(
+    contractId: number,
+    fileId: number
+  ): Promise<{ presignedURL: string; url: string }> {
     const url = this.getApiPath(`/contractFile/downloadURL/${fileId}`);
     let fullUrl = url;
-    if (this.authType === '2legged') {
+    if (this.authType === "2legged") {
       const queryParams = new URLSearchParams({ contractId: String(contractId) });
       fullUrl = `${url}?${queryParams}`;
     }
@@ -121,15 +140,20 @@ export class RCDEClient {
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = (await res.json()) as { presignedURL?: string; url?: string };
-    const presignedURL = data.presignedURL ?? data.url ?? '';
+    const presignedURL = data.presignedURL ?? data.url ?? "";
     return { url: presignedURL, presignedURL };
   }
 
   // アップロード開始（点群アップロードAPIを使用）
-  async uploadContractFile(params: { contractId: number; name: string; buffer: ArrayBuffer; pointCloudAttribute?: Record<string, unknown> }): Promise<Json> {
+  async uploadContractFile(params: {
+    contractId: number;
+    name: string;
+    buffer: ArrayBuffer;
+    pointCloudAttribute?: Record<string, unknown>;
+  }): Promise<Json> {
     const { contractId, name, buffer, pointCloudAttribute } = params;
     // まずアップロード開始APIを呼び出してpresignedURLを取得
-    const uploadUrl = this.getApiPath('/contractFile/pointCloud');
+    const uploadUrl = this.getApiPath("/contractFile/pointCloud");
     const uploadRequest = {
       contractId,
       name,
@@ -137,7 +161,7 @@ export class RCDEClient {
       pointCloudAttribute: pointCloudAttribute ?? {},
     };
     const uploadRes = await this.fetchImpl(uploadUrl, {
-      method: 'POST',
+      method: "POST",
       headers: this.headers(),
       body: JSON.stringify(uploadRequest),
     });
@@ -146,7 +170,7 @@ export class RCDEClient {
 
     // presignedURLにファイルをアップロード
     const uploadFileRes = await this.fetchImpl(uploadData.presignedURL, {
-      method: 'PUT',
+      method: "PUT",
       body: buffer,
     });
     if (!uploadFileRes.ok) throw new Error(`Upload failed: HTTP ${uploadFileRes.status}`);
@@ -154,7 +178,7 @@ export class RCDEClient {
     // アップロード完了を通知
     const completeUrl = this.getApiPath(`/contractFile/uploaded/${uploadData.contractFileId}`);
     const completeRes = await this.fetchImpl(completeUrl, {
-      method: 'PUT',
+      method: "PUT",
       headers: this.headers(),
       body: JSON.stringify({ contractId }),
     });
@@ -164,7 +188,7 @@ export class RCDEClient {
 
   // Construction関連のAPI
   async getConstructionList(): Promise<{ constructions: Construction[] }> {
-    const url = this.getApiPath('/construction');
+    const url = this.getApiPath("/construction");
     const res = await this.fetchImpl(url, {
       headers: this.headers(),
     });
@@ -183,9 +207,9 @@ export class RCDEClient {
   }
 
   async createConstruction(params: CreateConstructionParams): Promise<Json> {
-    const url = this.getApiPath('/construction');
+    const url = this.getApiPath("/construction");
     const res = await this.fetchImpl(url, {
-      method: 'POST',
+      method: "POST",
       headers: this.headers(),
       body: JSON.stringify(params),
     });
@@ -196,10 +220,10 @@ export class RCDEClient {
   // Contract関連のAPI
   async getContractList(params: { constructionId: number }): Promise<{ contracts: Contract[] }> {
     const { constructionId } = params;
-    const url = this.getApiPath('/contract');
+    const url = this.getApiPath("/contract");
     const queryParams = new URLSearchParams();
-    if (this.authType === '2legged' || constructionId) {
-      queryParams.append('constructionId', String(constructionId));
+    if (this.authType === "2legged" || constructionId) {
+      queryParams.append("constructionId", String(constructionId));
     }
     const fullUrl = queryParams.toString() ? `${url}?${queryParams}` : url;
     const res = await this.fetchImpl(fullUrl, {
@@ -210,9 +234,14 @@ export class RCDEClient {
     return { contracts: data.contracts ?? [] };
   }
 
-  async createContract(params: { constructionId: number; name: string; contractedAt: string; status?: string }): Promise<Json> {
+  async createContract(params: {
+    constructionId: number;
+    name: string;
+    contractedAt: string;
+    status?: string;
+  }): Promise<Json> {
     const { constructionId, name, contractedAt, status } = params;
-    const url = this.getApiPath('/contract');
+    const url = this.getApiPath("/contract");
     const requestBody: Record<string, unknown> = {
       name,
       contractedAt,
@@ -222,7 +251,7 @@ export class RCDEClient {
       requestBody.status = status;
     }
     const res = await this.fetchImpl(url, {
-      method: 'POST',
+      method: "POST",
       headers: this.headers(),
       body: JSON.stringify(requestBody),
     });

--- a/src/services/Picking.ts
+++ b/src/services/Picking.ts
@@ -1,5 +1,5 @@
-import { Box, Circle, Point, QuadTree } from 'js-quadtree';
-import { Camera, Vector3 } from 'three';
+import { Box, Circle, Point, QuadTree } from "js-quadtree";
+import { Camera, Vector3 } from "three";
 
 const buildTree = (props: {
   camera: Camera;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/types/chroma-js/index.d.ts
+++ b/types/chroma-js/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'chroma-js' {
+declare module "chroma-js" {
   interface ChromaScale {
     (value: number): ChromaInstance;
     colors(count?: number): string[];
@@ -26,11 +26,20 @@ declare module 'chroma-js' {
     hsl(h: number, s: number, l: number): ChromaInstance;
     hex(color: string): ChromaInstance;
     valid(color: unknown): boolean;
-    mix(color1: ChromaInstance | string, color2: ChromaInstance | string, ratio?: number, mode?: string): ChromaInstance;
-    interpolate(color1: ChromaInstance | string, color2: ChromaInstance | string, f: number, mode?: string): ChromaInstance;
+    mix(
+      color1: ChromaInstance | string,
+      color2: ChromaInstance | string,
+      ratio?: number,
+      mode?: string
+    ): ChromaInstance;
+    interpolate(
+      color1: ChromaInstance | string,
+      color2: ChromaInstance | string,
+      f: number,
+      mode?: string
+    ): ChromaInstance;
   }
 
   const chroma: Chroma;
   export default chroma;
 }
-

--- a/types/pngjs/index.d.ts
+++ b/types/pngjs/index.d.ts
@@ -1,8 +1,7 @@
-
-declare module 'pngjs/browser' {
+declare module "pngjs/browser" {
   export class PNG {
-    constructor ();
+    constructor();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    parse (data: ArrayBuffer): any;
+    parse(data: ArrayBuffer): any;
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,13 +20,7 @@ export default defineConfig(({ command }) => ({
       formats: ["es", "umd"],
     },
     rollupOptions: {
-      external: [
-        "react",
-        "react-dom",
-        "@react-three/fiber",
-        "@react-three/drei",
-        "three",
-      ],
+      external: ["react", "react-dom", "@react-three/fiber", "@react-three/drei", "three"],
       output: {
         globals: {
           react: "React",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+// SDK 本体のユニットテスト設定（ビルド用 vite.config.ts とは分離）
+export default defineConfig({
+  test: {
+    globals: true,
+    // Blob / ReadableStream / FormData / fetch は Node 22 でグローバル提供されるため node 環境で十分
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,85 +199,170 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz#5e13fac887f08c44f76b0ccaf3370eb00fec9bb6"
   integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
 
+"@esbuild/aix-ppc64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz#c7184a326533fcdf1b8ee0733e21c713b975575f"
+  integrity sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==
+
 "@esbuild/aix-ppc64@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz#80fcbe36130e58b7670511e888b8e88a259ed76c"
   integrity sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==
+
+"@esbuild/android-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz#09d9b4357780da9ea3a7dfb833a1f1ff439b4052"
+  integrity sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==
 
 "@esbuild/android-arm64@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz#8aa4965f8d0a7982dc21734bf6601323a66da752"
   integrity sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==
 
+"@esbuild/android-arm@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.21.5.tgz#9b04384fb771926dfa6d7ad04324ecb2ab9b2e28"
+  integrity sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==
+
 "@esbuild/android-arm@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.12.tgz#300712101f7f50f1d2627a162e6e09b109b6767a"
   integrity sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==
+
+"@esbuild/android-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.21.5.tgz#29918ec2db754cedcb6c1b04de8cd6547af6461e"
+  integrity sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==
 
 "@esbuild/android-x64@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.12.tgz#87dfb27161202bdc958ef48bb61b09c758faee16"
   integrity sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==
 
+"@esbuild/darwin-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz#e495b539660e51690f3928af50a76fb0a6ccff2a"
+  integrity sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
+
 "@esbuild/darwin-arm64@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz#79197898ec1ff745d21c071e1c7cc3c802f0c1fd"
   integrity sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==
+
+"@esbuild/darwin-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz#c13838fa57372839abdddc91d71542ceea2e1e22"
+  integrity sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==
 
 "@esbuild/darwin-x64@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz#146400a8562133f45c4d2eadcf37ddd09718079e"
   integrity sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==
 
+"@esbuild/freebsd-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz#646b989aa20bf89fd071dd5dbfad69a3542e550e"
+  integrity sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==
+
 "@esbuild/freebsd-arm64@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz#1c5f9ba7206e158fd2b24c59fa2d2c8bb47ca0fe"
   integrity sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==
+
+"@esbuild/freebsd-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz#aa615cfc80af954d3458906e38ca22c18cf5c261"
+  integrity sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==
 
 "@esbuild/freebsd-x64@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz#ea631f4a36beaac4b9279fa0fcc6ca29eaeeb2b3"
   integrity sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==
 
+"@esbuild/linux-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz#70ac6fa14f5cb7e1f7f887bcffb680ad09922b5b"
+  integrity sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==
+
 "@esbuild/linux-arm64@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz#e1066bce58394f1b1141deec8557a5f0a22f5977"
   integrity sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==
+
+"@esbuild/linux-arm@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz#fc6fd11a8aca56c1f6f3894f2bea0479f8f626b9"
+  integrity sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==
 
 "@esbuild/linux-arm@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz#452cd66b20932d08bdc53a8b61c0e30baf4348b9"
   integrity sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==
 
+"@esbuild/linux-ia32@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz#3271f53b3f93e3d093d518d1649d6d68d346ede2"
+  integrity sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==
+
 "@esbuild/linux-ia32@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz#b24f8acc45bcf54192c7f2f3be1b53e6551eafe0"
   integrity sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==
+
+"@esbuild/linux-loong64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz#ed62e04238c57026aea831c5a130b73c0f9f26df"
+  integrity sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==
 
 "@esbuild/linux-loong64@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz#f9cfffa7fc8322571fbc4c8b3268caf15bd81ad0"
   integrity sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==
 
+"@esbuild/linux-mips64el@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz#e79b8eb48bf3b106fadec1ac8240fb97b4e64cbe"
+  integrity sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==
+
 "@esbuild/linux-mips64el@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz#575a14bd74644ffab891adc7d7e60d275296f2cd"
   integrity sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==
+
+"@esbuild/linux-ppc64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz#5f2203860a143b9919d383ef7573521fb154c3e4"
+  integrity sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==
 
 "@esbuild/linux-ppc64@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz#75b99c70a95fbd5f7739d7692befe60601591869"
   integrity sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==
 
+"@esbuild/linux-riscv64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz#07bcafd99322d5af62f618cb9e6a9b7f4bb825dc"
+  integrity sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==
+
 "@esbuild/linux-riscv64@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz#2e3259440321a44e79ddf7535c325057da875cd6"
   integrity sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==
 
+"@esbuild/linux-s390x@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz#b7ccf686751d6a3e44b8627ababc8be3ef62d8de"
+  integrity sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==
+
 "@esbuild/linux-s390x@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz#17676cabbfe5928da5b2a0d6df5d58cd08db2663"
   integrity sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==
+
+"@esbuild/linux-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz#6d8f0c768e070e64309af8004bb94e68ab2bb3b0"
+  integrity sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==
 
 "@esbuild/linux-x64@0.25.12":
   version "0.25.12"
@@ -289,6 +374,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz#f04c4049cb2e252fe96b16fed90f70746b13f4a4"
   integrity sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==
 
+"@esbuild/netbsd-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz#bbe430f60d378ecb88decb219c602667387a6047"
+  integrity sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==
+
 "@esbuild/netbsd-x64@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz#77da0d0a0d826d7c921eea3d40292548b258a076"
@@ -298,6 +388,11 @@
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz#6296f5867aedef28a81b22ab2009c786a952dccd"
   integrity sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==
+
+"@esbuild/openbsd-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz#99d1cf2937279560d2104821f5ccce220cb2af70"
+  integrity sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==
 
 "@esbuild/openbsd-x64@0.25.12":
   version "0.25.12"
@@ -309,20 +404,40 @@
   resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz#49e0b768744a3924be0d7fd97dd6ce9b2923d88d"
   integrity sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==
 
+"@esbuild/sunos-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz#08741512c10d529566baba837b4fe052c8f3487b"
+  integrity sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==
+
 "@esbuild/sunos-x64@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz#a6ed7d6778d67e528c81fb165b23f4911b9b13d6"
   integrity sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==
+
+"@esbuild/win32-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz#675b7385398411240735016144ab2e99a60fc75d"
+  integrity sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==
 
 "@esbuild/win32-arm64@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz#9ac14c378e1b653af17d08e7d3ce34caef587323"
   integrity sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==
 
+"@esbuild/win32-ia32@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz#1bfc3ce98aa6ca9a0969e4d2af72144c59c1193b"
+  integrity sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==
+
 "@esbuild/win32-ia32@0.25.12":
   version "0.25.12"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz#918942dcbbb35cc14fca39afb91b5e6a3d127267"
   integrity sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==
+
+"@esbuild/win32-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz#acad351d582d157bb145535db2a6ff53dd514b5c"
+  integrity sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==
 
 "@esbuild/win32-x64@0.25.12":
   version "0.25.12"
@@ -755,125 +870,250 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz#a19c645c375158cd5c50a344106f0fa18eb821c4"
   integrity sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==
 
+"@rollup/rollup-android-arm-eabi@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz#5e9849b661c2229cf967a08dbe2dbbe9e8c991e5"
+  integrity sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==
+
 "@rollup/rollup-android-arm64@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz#1af19aa9d3ad6d00df2681f59cfcb8bf7499576b"
   integrity sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==
+
+"@rollup/rollup-android-arm64@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz#5b0699ee5dd484b222c9ed74aff43c91ea8b17f8"
+  integrity sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==
 
 "@rollup/rollup-darwin-arm64@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz#3b8463e03ba2a393453fea70e7d907379c27b649"
   integrity sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==
 
+"@rollup/rollup-darwin-arm64@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz#8bc52c9d7a3ce8d0533c351a9c935de781daa06f"
+  integrity sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==
+
 "@rollup/rollup-darwin-x64@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz#28da23d69fe117f5f0ff330a8549e51bd09f1b6a"
   integrity sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==
+
+"@rollup/rollup-darwin-x64@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz#ba2ef3e8fb310f0af35588f270cfa5aa96e48764"
+  integrity sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==
 
 "@rollup/rollup-freebsd-arm64@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz#94bacac3190f621de1355922b599f3817786044c"
   integrity sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==
 
+"@rollup/rollup-freebsd-arm64@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz#93b10bdbfe8ada226b8bc0c02ef6b7f544474d96"
+  integrity sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==
+
 "@rollup/rollup-freebsd-x64@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz#8a0094f533b9fda160b5c90ad9e0c78fca341788"
   integrity sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==
+
+"@rollup/rollup-freebsd-x64@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz#3e8aa38ef3c9c300946871e3fdbb0c30e0a20f86"
+  integrity sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==
 
 "@rollup/rollup-linux-arm-gnueabihf@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz#3b7e901a555c7245c87f7440979bee0a1ec882bb"
   integrity sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==
 
+"@rollup/rollup-linux-arm-gnueabihf@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz#1d7994384bb0ad1bc41921b506e1642d4f9d7fc3"
+  integrity sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==
+
 "@rollup/rollup-linux-arm-musleabihf@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz#ee9a09b72e8ad764cfd6188b32ff1de528ff7ebe"
   integrity sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==
+
+"@rollup/rollup-linux-arm-musleabihf@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz#a6540f47cf844a56b80ca9ff95d2acdfb2cef97b"
+  integrity sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==
 
 "@rollup/rollup-linux-arm64-gnu@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz#ba483f4aca9be141171d086dbd01ada6ab03b58d"
   integrity sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==
 
+"@rollup/rollup-linux-arm64-gnu@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz#404f2045651840cbf48da91ba6d0f490f0bc2cbf"
+  integrity sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==
+
 "@rollup/rollup-linux-arm64-musl@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz#17b595b790e6df68e91c5d02526fc832a985ce4f"
   integrity sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==
+
+"@rollup/rollup-linux-arm64-musl@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz#a3404ffddf7b474b48c99b9c893b6247bb765ba5"
+  integrity sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==
 
 "@rollup/rollup-linux-loong64-gnu@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz#551718714075a2bfb36a2813c466e3a0e9d56abf"
   integrity sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==
 
+"@rollup/rollup-linux-loong64-gnu@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz#e8aac6d549b377945e349882f199b7c8eb75ca38"
+  integrity sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==
+
 "@rollup/rollup-linux-loong64-musl@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz#ba156ed1243447a3d710972001d5dcfe3827ff3d"
   integrity sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==
+
+"@rollup/rollup-linux-loong64-musl@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz#6e2e44ea50310b3a582078a915e5feb879c820d4"
+  integrity sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==
 
 "@rollup/rollup-linux-ppc64-gnu@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz#6a957a709b86ac62ef68e597ac03dbd4336782b1"
   integrity sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==
 
+"@rollup/rollup-linux-ppc64-gnu@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz#6898302da6d77a0537cde64b2b4c6b60659bd110"
+  integrity sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==
+
 "@rollup/rollup-linux-ppc64-musl@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz#ca4176b4ad53f3edee3b4bfa6f9ef48ff38f167b"
   integrity sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==
+
+"@rollup/rollup-linux-ppc64-musl@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz#333717c95dd5a66bef8f63e7ef8a9fd845fd18d0"
+  integrity sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==
 
 "@rollup/rollup-linux-riscv64-gnu@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz#4e6b08f72ebeafdb41f3ec433bd228ba8573473b"
   integrity sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==
 
+"@rollup/rollup-linux-riscv64-gnu@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz#81bc06ba380352004d01f4826eb7cdccefa05bad"
+  integrity sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==
+
 "@rollup/rollup-linux-riscv64-musl@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz#a0b8b8580c7680c8086cb3226527e5472253b895"
   integrity sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==
+
+"@rollup/rollup-linux-riscv64-musl@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz#95a7cd39de21389ad6788a5284eaaa738e29ca4c"
+  integrity sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==
 
 "@rollup/rollup-linux-s390x-gnu@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz#79fe15b92ce0bae2b609cf26dd158cd3e2b73634"
   integrity sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==
 
+"@rollup/rollup-linux-s390x-gnu@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz#06e6db2ec1bc48b5374c7923ef83c2eb024b2452"
+  integrity sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==
+
 "@rollup/rollup-linux-x64-gnu@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz#6aa8302fa45fd3cbbc510ccd223c9c37bf67e53f"
   integrity sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==
+
+"@rollup/rollup-linux-x64-gnu@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz#5dc818988285e09e88790c6462def72413df2da3"
+  integrity sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==
 
 "@rollup/rollup-linux-x64-musl@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz#0c1a5e9799f80c47a66f2c3a5f1a280f38356047"
   integrity sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==
 
+"@rollup/rollup-linux-x64-musl@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz#2080f4a93349e9afd34be6fc1a37e01fc8bfc80f"
+  integrity sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==
+
 "@rollup/rollup-openbsd-x64@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz#5f07c863e74fd428794f1dc5749f321b661d1f17"
   integrity sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==
+
+"@rollup/rollup-openbsd-x64@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz#21d64a8acb66221724b923e51af5333df1af044b"
+  integrity sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==
 
 "@rollup/rollup-openharmony-arm64@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz#8e0d71324be0f423428b12b25a2eb8ea8e0a7833"
   integrity sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==
 
+"@rollup/rollup-openharmony-arm64@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz#8e0fcd9d02141e337b4c5b5cff576cb9a76b1ba0"
+  integrity sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==
+
 "@rollup/rollup-win32-arm64-msvc@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz#a553fdf90a785ace6d7501eed6241c468b088999"
   integrity sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==
+
+"@rollup/rollup-win32-arm64-msvc@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz#bdb4cc4efd58efe808203347f0f5463f0ea16e52"
+  integrity sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==
 
 "@rollup/rollup-win32-ia32-msvc@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz#0fb04f0a88027fbfd323e25a446debce4773868c"
   integrity sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==
 
+"@rollup/rollup-win32-ia32-msvc@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz#dbaebde5afd24eae0eefe915d901632e7cb59860"
+  integrity sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==
+
 "@rollup/rollup-win32-x64-gnu@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz#aaa9e36dbdc0f0e397e5966dcce1b4285354ede2"
   integrity sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==
 
+"@rollup/rollup-win32-x64-gnu@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz#84109e85fea5f8f1353499f96578fdc2a0e8b138"
+  integrity sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==
+
 "@rollup/rollup-win32-x64-msvc@4.60.2":
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz#3418dcf1388f2abd6b0ccc08fe1ef205ae76d696"
   integrity sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==
+
+"@rollup/rollup-win32-x64-msvc@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz#3671ce3f9b928d5c01f879792d5c0b60ae14d4ad"
+  integrity sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==
 
 "@rushstack/node-core-library@5.23.1":
   version "5.23.1"
@@ -1038,6 +1278,11 @@
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
+
+"@types/estree@1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.9.tgz#cf3f0e876d7bee15a93ab925b82bf570a3904a24"
+  integrity sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==
 
 "@types/json-schema@^7.0.15":
   version "7.0.15"
@@ -1254,6 +1499,65 @@
     "@rolldown/pluginutils" "1.0.0-beta.27"
     "@swc/core" "^1.12.11"
 
+"@vitest/expect@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-2.1.9.tgz#b566ea20d58ea6578d8dc37040d6c1a47ebe5ff8"
+  integrity sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==
+  dependencies:
+    "@vitest/spy" "2.1.9"
+    "@vitest/utils" "2.1.9"
+    chai "^5.1.2"
+    tinyrainbow "^1.2.0"
+
+"@vitest/mocker@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-2.1.9.tgz#36243b27351ca8f4d0bbc4ef91594ffd2dc25ef5"
+  integrity sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==
+  dependencies:
+    "@vitest/spy" "2.1.9"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.12"
+
+"@vitest/pretty-format@2.1.9", "@vitest/pretty-format@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-2.1.9.tgz#434ff2f7611689f9ce70cd7d567eceb883653fdf"
+  integrity sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==
+  dependencies:
+    tinyrainbow "^1.2.0"
+
+"@vitest/runner@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-2.1.9.tgz#cc18148d2d797fd1fd5908d1f1851d01459be2f6"
+  integrity sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==
+  dependencies:
+    "@vitest/utils" "2.1.9"
+    pathe "^1.1.2"
+
+"@vitest/snapshot@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-2.1.9.tgz#24260b93f798afb102e2dcbd7e61c6dfa118df91"
+  integrity sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==
+  dependencies:
+    "@vitest/pretty-format" "2.1.9"
+    magic-string "^0.30.12"
+    pathe "^1.1.2"
+
+"@vitest/spy@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-2.1.9.tgz#cb28538c5039d09818b8bfa8edb4043c94727c60"
+  integrity sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==
+  dependencies:
+    tinyspy "^3.0.2"
+
+"@vitest/utils@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-2.1.9.tgz#4f2486de8a54acf7ecbf2c5c24ad7994a680a6c1"
+  integrity sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==
+  dependencies:
+    "@vitest/pretty-format" "2.1.9"
+    loupe "^3.1.2"
+    tinyrainbow "^1.2.0"
+
 "@volar/language-core@2.4.28", "@volar/language-core@~2.4.11":
   version "2.4.28"
   resolved "https://registry.yarnpkg.com/@volar/language-core/-/language-core-2.4.28.tgz#c21f365a91c1dffe8bd7264fd491770c8d74fef3"
@@ -1400,6 +1704,11 @@ argparse@~1.0.9:
   dependencies:
     sprintf-js "~1.0.2"
 
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
 babel-plugin-macros@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz#9ef6dc74deb934b4db344dc973ee851d148c50c1"
@@ -1461,6 +1770,11 @@ buffer@^6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
+cac@^6.7.14:
+  version "6.7.14"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
+  integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -1471,6 +1785,17 @@ camera-controls@^2.9.0:
   resolved "https://registry.yarnpkg.com/camera-controls/-/camera-controls-2.10.1.tgz#78bc58001a2d5925c29312154ce77d16967dec56"
   integrity sha512-KnaKdcvkBJ1Irbrzl8XD6WtZltkRjp869Jx8c0ujs9K+9WD+1D7ryBsCiVqJYUqt6i/HR5FxT7RLASieUD+Q5w==
 
+chai@^5.1.2:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.3.3.tgz#dd3da955e270916a4bd3f625f4b919996ada7e06"
+  integrity sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==
+  dependencies:
+    assertion-error "^2.0.1"
+    check-error "^2.1.1"
+    deep-eql "^5.0.1"
+    loupe "^3.1.0"
+    pathval "^2.0.0"
+
 chalk@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -1478,6 +1803,11 @@ chalk@^4.0.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+check-error@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.3.tgz#2427361117b70cca8dc89680ead32b157019caf5"
+  integrity sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==
 
 chroma-js@^3.1.2:
   version "3.2.0"
@@ -1570,12 +1900,17 @@ de-indent@^1.0.2:
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==
 
-debug@^4.3.1, debug@^4.3.2, debug@^4.4.0, debug@^4.4.3:
+debug@^4.3.1, debug@^4.3.2, debug@^4.3.7, debug@^4.4.0, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
+
+deep-eql@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
+  integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
 
 deep-is@^0.1.3:
   version "0.1.4"
@@ -1623,6 +1958,40 @@ es-errors@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
+es-module-lexer@^1.5.4:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
+
+esbuild@^0.21.3:
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.21.5.tgz#9ca301b120922959b766360d8ac830da0d02997d"
+  integrity sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.21.5"
+    "@esbuild/android-arm" "0.21.5"
+    "@esbuild/android-arm64" "0.21.5"
+    "@esbuild/android-x64" "0.21.5"
+    "@esbuild/darwin-arm64" "0.21.5"
+    "@esbuild/darwin-x64" "0.21.5"
+    "@esbuild/freebsd-arm64" "0.21.5"
+    "@esbuild/freebsd-x64" "0.21.5"
+    "@esbuild/linux-arm" "0.21.5"
+    "@esbuild/linux-arm64" "0.21.5"
+    "@esbuild/linux-ia32" "0.21.5"
+    "@esbuild/linux-loong64" "0.21.5"
+    "@esbuild/linux-mips64el" "0.21.5"
+    "@esbuild/linux-ppc64" "0.21.5"
+    "@esbuild/linux-riscv64" "0.21.5"
+    "@esbuild/linux-s390x" "0.21.5"
+    "@esbuild/linux-x64" "0.21.5"
+    "@esbuild/netbsd-x64" "0.21.5"
+    "@esbuild/openbsd-x64" "0.21.5"
+    "@esbuild/sunos-x64" "0.21.5"
+    "@esbuild/win32-arm64" "0.21.5"
+    "@esbuild/win32-ia32" "0.21.5"
+    "@esbuild/win32-x64" "0.21.5"
 
 esbuild@^0.25.0:
   version "0.25.12"
@@ -1767,10 +2136,22 @@ estree-walker@^2.0.2:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+expect-type@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
+  integrity sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==
 
 exsolve@^1.0.7:
   version "1.0.8"
@@ -2120,12 +2501,17 @@ loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+loupe@^3.1.0, loupe@^3.1.2:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.2.1.tgz#0095cf56dc5b7a9a7c08ff5b1a8796ec8ad17e76"
+  integrity sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==
+
 maath@^0.10.8:
   version "0.10.8"
   resolved "https://registry.yarnpkg.com/maath/-/maath-0.10.8.tgz#cf647544430141bf6982da6e878abb6c4b804e24"
   integrity sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==
 
-magic-string@^0.30.17:
+magic-string@^0.30.12, magic-string@^0.30.17:
   version "0.30.21"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
   integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
@@ -2199,6 +2585,11 @@ nanoid@^3.3.11:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+
+nanoid@^3.3.12:
+  version "3.3.15"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.15.tgz#36c490fad8c6e86c824c940dfdde999b69ed4316"
+  integrity sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -2278,10 +2669,20 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pathe@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
+  integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
+
 pathe@^2.0.1, pathe@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
+pathval@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.1.tgz#8855c5a2899af072d6ac05d11e46045ad0dc605d"
+  integrity sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==
 
 picocolors@^1.1.1:
   version "1.1.1"
@@ -2316,6 +2717,15 @@ pngjs@^7.0.0:
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-7.0.0.tgz#a8b7446020ebbc6ac739db6c5415a65d17090e26"
   integrity sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==
 
+postcss@^8.4.43:
+  version "8.5.15"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.15.tgz#d1eaf677a324e9ec02196da2d3fecf4a0b9a735c"
+  integrity sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==
+  dependencies:
+    nanoid "^3.3.12"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
 postcss@^8.5.3:
   version "8.5.10"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.10.tgz#8992d8c30acf3f12169e7c09514a12fed7e48356"
@@ -2334,6 +2744,11 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prettier@^3.8.4:
+  version "3.8.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.4.tgz#f334f013ac04a96676f24dabc23c1c4ae1bae411"
+  integrity sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==
 
 promise-worker-transferable@^1.0.4:
   version "1.0.4"
@@ -2442,6 +2857,40 @@ resolve@^1.19.0, resolve@~1.22.1, resolve@~1.22.2:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+rollup@^4.20.0:
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.62.2.tgz#d90fc4cb811f071303c890b779595634f35f9541"
+  integrity sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==
+  dependencies:
+    "@types/estree" "1.0.9"
+  optionalDependencies:
+    "@rollup/rollup-android-arm-eabi" "4.62.2"
+    "@rollup/rollup-android-arm64" "4.62.2"
+    "@rollup/rollup-darwin-arm64" "4.62.2"
+    "@rollup/rollup-darwin-x64" "4.62.2"
+    "@rollup/rollup-freebsd-arm64" "4.62.2"
+    "@rollup/rollup-freebsd-x64" "4.62.2"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.62.2"
+    "@rollup/rollup-linux-arm-musleabihf" "4.62.2"
+    "@rollup/rollup-linux-arm64-gnu" "4.62.2"
+    "@rollup/rollup-linux-arm64-musl" "4.62.2"
+    "@rollup/rollup-linux-loong64-gnu" "4.62.2"
+    "@rollup/rollup-linux-loong64-musl" "4.62.2"
+    "@rollup/rollup-linux-ppc64-gnu" "4.62.2"
+    "@rollup/rollup-linux-ppc64-musl" "4.62.2"
+    "@rollup/rollup-linux-riscv64-gnu" "4.62.2"
+    "@rollup/rollup-linux-riscv64-musl" "4.62.2"
+    "@rollup/rollup-linux-s390x-gnu" "4.62.2"
+    "@rollup/rollup-linux-x64-gnu" "4.62.2"
+    "@rollup/rollup-linux-x64-musl" "4.62.2"
+    "@rollup/rollup-openbsd-x64" "4.62.2"
+    "@rollup/rollup-openharmony-arm64" "4.62.2"
+    "@rollup/rollup-win32-arm64-msvc" "4.62.2"
+    "@rollup/rollup-win32-ia32-msvc" "4.62.2"
+    "@rollup/rollup-win32-x64-gnu" "4.62.2"
+    "@rollup/rollup-win32-x64-msvc" "4.62.2"
+    fsevents "~2.3.2"
+
 rollup@^4.34.9:
   version "4.60.2"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.60.2.tgz#ac23fe4bd530304cef9fa61e639d7098b6762cf4"
@@ -2507,6 +2956,11 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
@@ -2527,6 +2981,11 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
 stats-gl@^2.2.8:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/stats-gl/-/stats-gl-2.4.2.tgz#28a6c869fc3a36a8be608ef21df63c0aad99d1ba"
@@ -2539,6 +2998,11 @@ stats.js@^0.17.0:
   version "0.17.0"
   resolved "https://registry.yarnpkg.com/stats.js/-/stats.js-0.17.0.tgz#b1c3dc46d94498b578b7fd3985b81ace7131cc7d"
   integrity sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==
+
+std-env@^3.8.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.10.0.tgz#d810b27e3a073047b2b5e40034881f5ea6f9c83b"
+  integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
 
 string-argv@~0.3.1:
   version "0.3.2"
@@ -2606,6 +3070,16 @@ three@^0.171.0:
   resolved "https://registry.yarnpkg.com/three/-/three-0.171.0.tgz#3c0dd3f8fa14e78a7f8db6e416b98f264f1185c0"
   integrity sha512-Y/lAXPaKZPcEdkKjh0JOAHVv8OOnv/NDJqm0wjfCzyQmfKxV7zvkwsnBgPBKTzJHToSOhRGQAGbPJObT59B/PQ==
 
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
+  integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
+
 tinyglobby@^0.2.13, tinyglobby@^0.2.15:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.16.tgz#1c3b7eb953fce42b226bc5a1ee06428281aff3d6"
@@ -2613,6 +3087,21 @@ tinyglobby@^0.2.13, tinyglobby@^0.2.15:
   dependencies:
     fdir "^6.5.0"
     picomatch "^4.0.4"
+
+tinypool@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.1.1.tgz#059f2d042bd37567fbc017d3d426bdd2a2612591"
+  integrity sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==
+
+tinyrainbow@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-1.2.0.tgz#5c57d2fc0fb3d1afd78465c33ca885d04f02abb5"
+  integrity sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==
+
+tinyspy@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-3.0.2.tgz#86dd3cf3d737b15adcf17d7887c84a75201df20a"
+  integrity sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==
 
 troika-three-text@^0.52.0:
   version "0.52.4"
@@ -2710,6 +3199,17 @@ utility-types@^3.11.0:
   resolved "https://registry.yarnpkg.com/utility-types/-/utility-types-3.11.0.tgz#607c40edb4f258915e901ea7995607fdf319424c"
   integrity sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==
 
+vite-node@2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-2.1.9.tgz#549710f76a643f1c39ef34bdb5493a944e4f895f"
+  integrity sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.3.7"
+    es-module-lexer "^1.5.4"
+    pathe "^1.1.2"
+    vite "^5.0.0"
+
 vite-plugin-dts@^4.4.0:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/vite-plugin-dts/-/vite-plugin-dts-4.5.4.tgz#51b60aaaa760d9cf5c2bb3676c69d81910d6b08c"
@@ -2725,6 +3225,17 @@ vite-plugin-dts@^4.4.0:
     local-pkg "^1.0.0"
     magic-string "^0.30.17"
 
+vite@^5.0.0:
+  version "5.4.21"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.21.tgz#84a4f7c5d860b071676d39ba513c0d598fdc7027"
+  integrity sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==
+  dependencies:
+    esbuild "^0.21.3"
+    postcss "^8.4.43"
+    rollup "^4.20.0"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
 vite@^6.0.1:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/vite/-/vite-6.4.2.tgz#a4e548ca3a90ca9f3724582cab35e1ba15efc6f2"
@@ -2738,6 +3249,32 @@ vite@^6.0.1:
     tinyglobby "^0.2.13"
   optionalDependencies:
     fsevents "~2.3.3"
+
+vitest@^2.1:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-2.1.9.tgz#7d01ffd07a553a51c87170b5e80fea3da7fb41e7"
+  integrity sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==
+  dependencies:
+    "@vitest/expect" "2.1.9"
+    "@vitest/mocker" "2.1.9"
+    "@vitest/pretty-format" "^2.1.9"
+    "@vitest/runner" "2.1.9"
+    "@vitest/snapshot" "2.1.9"
+    "@vitest/spy" "2.1.9"
+    "@vitest/utils" "2.1.9"
+    chai "^5.1.2"
+    debug "^4.3.7"
+    expect-type "^1.1.0"
+    magic-string "^0.30.12"
+    pathe "^1.1.2"
+    std-env "^3.8.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.1"
+    tinypool "^1.0.1"
+    tinyrainbow "^1.2.0"
+    vite "^5.0.0"
+    vite-node "2.1.9"
+    why-is-node-running "^2.3.0"
 
 vscode-uri@^3.0.8:
   version "3.1.0"
@@ -2760,6 +3297,14 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 word-wrap@^1.2.5:
   version "1.2.5"


### PR DESCRIPTION
## 関連チケット
[単体テスト](https://app.notion.com/p/amdlab/84b24f2fe22e4529af49b1fbb4248a37)

## 内容

**背景**

`rcde-frontend-sdk` の `develop` ブランチには GitHub Actions がなく、`lint` / `build` も PR 上で自動検証されていなかった。
フォーマット用の Prettier も未導入のため、コードスタイルの逸脱を機械的に検知できなかった。

**本 PR でやること**

- vitest によるユニットテスト実行基盤を追加する（`vitest.config.ts`、`yarn test`）
- Prettier を導入し、既存コードに初回フォーマットを適用する（`.prettierrc`、`.prettierignore`、`yarn format:check`）
- GitHub Actions ワークフロー `CI`（`.github/workflows/ci.yml`）で `yarn lint` → `yarn format:check` → `yarn build` → `yarn test` を実行する
- `tsconfig.json` で `src/**/*.test.ts` をビルド対象から除外する（将来のテスト追加に備える）

**本 PR でやらないこと**

- api-server 統合（`src/api/`、`@i-con/frontend-sdk/api-server` エントリポイント）
- React 19 / `@react-three/fiber` 9 対応
- `example-poc/` サンプルアプリ
- 実ユニットテストの追加（テストファイルは 0 件のまま。`passWithNoTests: true` で CI を通す）

## 変更

[`5a3953b`](https://github.com/i-Construction/rcde-frontend-sdk/commit/5a3953bf02d21288dd581af8f00d6988e0dc88f7) chore: CI 基盤（vitest / Prettier / GitHub Actions）を追加

- `.github/workflows/ci.yml` — push / pull_request で lint・format・build・test を実行
- `vitest.config.ts` — Node 22 環境、`src/**/*.test.ts` を対象
- `.prettierrc` / `.prettierignore` — Prettier 設定と除外パス
- `package.json` — `test` / `format` / `format:check` スクリプト、vitest・prettier devDependency
- `tsconfig.json` — テストファイルを `exclude`
- `src/` / `example/` 等 — Prettier 初回適用によるフォーマットのみ（ロジック変更なし）

## 検証

ローカルで `yarn lint`、`yarn format:check`、`yarn build`、`yarn test` を実行し、いずれも成功した。
マージ後、本 PR 上で `CI` ワークフローが緑になることを確認予定。
